### PR TITLE
Add unsubscribe function to Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .ropeproject
+.idea
 *.py[cod]
 
 # Packages

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+.ropeproject
+*.py[cod]
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg

--- a/nats/__init__.py
+++ b/nats/__init__.py
@@ -1,1 +1,2 @@
-from nats.io.client import Client
+__version__  = b'0.2.2'
+__lang__     = b'python2'

--- a/nats/io/__init__.py
+++ b/nats/io/__init__.py
@@ -1,1 +1,4 @@
 # Copyright 2015 Apcera Inc. All rights reserved.
+from nats.io.client import Client
+
+__all__ = ['Client']

--- a/nats/io/client.py
+++ b/nats/io/client.py
@@ -409,6 +409,14 @@ class Client(object):
     unsub_cmd = UNSUB_PROTO.format(UNSUB_OP, sid, limit, _CRLF_)
     self.send_command(unsub_cmd)
 
+  @tornado.gen.coroutine
+  def unsubscribe(self, sid):
+    """
+    Sends an UNSUB command to the server and unsubscribes immediatedly.
+    """
+    unsub_cmd = UNSUB_PROTO.format(UNSUB_OP, sid, _EMPTY_, _CRLF_)
+    self.send_command(unsub_cmd)
+
   def _process_ping(self):
     """
     The server will be periodically sending a PING, and if the the client

--- a/nats/io/client.py
+++ b/nats/io/client.py
@@ -17,8 +17,6 @@ from nats.io.errors import *
 from nats.io.utils  import *
 from nats.protocol.parser import *
 
-__version__  = b'0.2.2'
-__lang__     = b'python2'
 _CRLF_       = b'\r\n'
 _SPC_        = b' '
 _EMPTY_      = b''

--- a/readme.md
+++ b/readme.md
@@ -18,16 +18,7 @@ with [gnatsd](https://github.com/nats-io/gnatsd) as the server:
 ## Getting Started
 
 ```bash
-git clone https://github.com/nats-io/python-nats
-cd python-nats
-
-# Only dependency is Tornado so it must be installed first: 
-pip install tornado
-
-# OR using pip
-pip install -r requirements.txt
-
-python setup.py install
+pip install nats-client
 ```
 
 ## Basic Usage
@@ -39,7 +30,7 @@ import tornado.gen
 import time
 from datetime import datetime
 from nats.io.utils  import new_inbox
-from nats.io.client import Client as NATS
+from nats.io import Client as NATS
 
 @tornado.gen.coroutine
 def main():
@@ -111,7 +102,7 @@ if __name__ == '__main__':
 import tornado.ioloop
 import tornado.gen
 from datetime import timedelta
-from nats.io.client import Client as NATS
+from nats.io import Client as NATS
 from nats.io.errors import ErrConnectionClosed
 
 @tornado.gen.coroutine
@@ -184,7 +175,7 @@ if __name__ == '__main__':
 import tornado.ioloop
 import tornado.gen
 import time
-from nats.io.client import Client as NATS
+from nats.io import Client as NATS
 
 @tornado.gen.coroutine
 def main():
@@ -215,7 +206,7 @@ if __name__ == '__main__':
 import tornado.ioloop
 import tornado.gen
 import time
-from nats.io.client import Client as NATS
+from nats.io import Client as NATS
 
 @tornado.gen.coroutine
 def main():

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, find_packages
-from nats.io.client import __version__
+from nats import __version__
 
 setup(
   name='nats-client',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 from nats.io.client import __version__
 
 setup(
@@ -10,9 +10,7 @@ setup(
   author='Waldemar Quevedo',
   author_email='wally@apcera.com',
   license='MIT License',
-  packages=['nats', 'nats.io', 'nats.protocol'],
-  install_requires=[
-    'tornado',
-  ],
+  packages=find_packages(),
+  install_requires=['tornado==4.2'],
   zip_safe=True,
 )


### PR DESCRIPTION
Currently only `auto_unsubscribe(sid, limit)` is exposed on the client.  I can unsubscribe immediately by passing in an empty string as the limit, but this feels a bit weird.  I would much prefer to be able to just call `unsubscribe(sid)`

Also added a .gitignore to exclude package files, project folders, and .pyc files.