### PR TITLE
publish_request() should be flushed like publish()

### DIFF
--- a/nats/io/client.py
+++ b/nats/io/client.py
@@ -326,14 +326,7 @@ class Client(object):
       <<- MSG hello 2 5
 
     """
-    payload_size = len(payload)
-    if payload_size > self._max_payload_size:
-      raise ErrMaxPayload
-    if self.is_closed:
-      raise ErrConnectionClosed
-    yield self._publish(subject, _EMPTY_, payload, payload_size)
-    if self._flush_queue.empty():
-      yield self._flush_pending()
+    yield self.publish_request(subject, _EMPTY_, payload)
 
   @tornado.gen.coroutine
   def publish_request(self, subject, reply, payload):
@@ -352,6 +345,8 @@ class Client(object):
     if self.is_closed:
       raise ErrConnectionClosed
     yield self._publish(subject, reply, payload, payload_size)
+    if self._flush_queue.empty():
+      yield self._flush_pending()
 
   @tornado.gen.coroutine
   def flush(self, timeout=60):

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -640,7 +640,6 @@ class ClientTest(tornado.testing.AsyncTestCase):
           inbox = new_inbox()
           yield nc.publish_request("help.1", inbox, "hello")
           yield nc.publish_request("help.2", inbox, "world")
-          yield nc.flush()
           yield tornado.gen.sleep(1.0)
 
           http = tornado.httpclient.AsyncHTTPClient()


### PR DESCRIPTION
`publish_request()` wasn't flushing messages like `publish()` does.