### PR TITLE
don't process a message if the subscription has been removed

### DIFF
--- a/nats/io/client.py
+++ b/nats/io/client.py
@@ -537,11 +537,15 @@ class Client(object):
     dispatched to a passed callback.  In case there was not
     a callback, then it tries to set the message into a future.
     """
-    self.stats['in_msgs']  += 1
+    self.stats['in_msgs'] += 1
     self.stats['in_bytes'] += len(data)
 
     msg = Msg(subject=subject.decode(), reply=reply.decode(), data=data)
-    sub = self._subs[sid]
+
+    # Don't process the message if the subscription has been removed
+    sub = self._subs.get(sid)
+    if sub is None:
+      raise tornado.gen.Return()
     sub.received += 1
 
     if sub.max_msgs > 0 and sub.received >= sub.max_msgs:

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -814,6 +814,11 @@ class ClientTest(tornado.testing.AsyncTestCase):
           with self.assertRaises(tornado.gen.TimeoutError):
                yield nc.timed_request("hello", "world", timeout=0.5)
 
+     @tornado.testing.gen_test
+     def test_process_message_subscription_not_present(self):
+          nc = Client()
+          yield nc._process_msg(387, 'some-subject', 'some-reply', [0, 1, 2])
+
 class ClientAuthTest(tornado.testing.AsyncTestCase):
 
      def setUp(self):


### PR DESCRIPTION
If a subscription has been removed and a message for that subscription is processed, a KeyError will be raised trying to retrieve the subscription, this prevents that by dropping messages if a subscription can't be found.