### PR TITLE
Pin tornado version to less than 5 in requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-tornado>=4.2
+tornado>=4.2,<5.0

--- a/script/test.sh
+++ b/script/test.sh
@@ -3,7 +3,6 @@
 export PYTHONPATH=$(pwd)
 
 pip install --upgrade pip
-pip install unittest2
 pip install -r requirements.txt
 
 python tests/test.py

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1,9 +1,5 @@
 import sys
-
-if sys.version_info >= (2, 7):
-     import unittest
-else:
-    import unittest2 as unittest
+import unittest
 
 import tornado.httpclient
 import tornado.concurrent
@@ -254,7 +250,7 @@ class ClientTest(tornado.testing.AsyncTestCase):
           self.assertIn("host", info_keys)
           self.assertIn("port", info_keys)
           self.assertIn("auth_required", info_keys)
-          self.assertIn("ssl_required", info_keys)
+          self.assertIn("tls_required", info_keys)
           self.assertIn("max_payload", info_keys)
 
      @tornado.testing.gen_test(timeout=5)

--- a/tests/protocol_test.py
+++ b/tests/protocol_test.py
@@ -1,9 +1,5 @@
 import sys
-
-if sys.version_info >= (2, 7):
-     import unittest
-else:
-    import unittest2 as unittest
+import unittest
 
 import tornado.testing
 import tornado.gen


### PR DESCRIPTION
Seems like there are some breaking changes in tornado version 5.x. This library is currently requiring >= tornado 4.2. A major version update to tornado should probably require a major version update to python-nats. 

I also removed unittest2 as python 2.6 is no longer supported. Builds still intermittently fail, but I will look into that. They seem to be broken in master right now, so hopefully this is better. I plan on continuing to work on fixing it.

@wallyqs 