### PR TITLE
use requirements.txt in setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ A Python async client for the [NATS messaging system](https://nats.io).
 ## Supported platforms
 
 Should be compatible with following versions of [Python](https://www.python.org/)
-using [Tornado 4.2+](https://github.com/tornadoweb/tornado/tree/v4.2.0)
+using [Tornado 4.2+](https://github.com/tornadoweb/tornado/tree/v4.2.0) (less than 5.0)
 with [gnatsd](https://github.com/nats-io/gnatsd) as the server:
 
 - 2.7.x

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,10 @@
+import os
 from setuptools import setup, find_packages
 from nats import __version__
+
+this_dir = os.path.dirname(os.path.abspath(__file__))
+with open(os.path.join(this_dir, 'requirements.txt')) as f:
+    requirements = f.read().splitlines()
 
 setup(
     name='nats-client',
@@ -11,7 +16,7 @@ setup(
     author_email='wally@apcera.com',
     license='Apache 2.0 License',
     packages=['nats', 'nats.io', 'nats.protocol'],
-    install_requires=['tornado>=4.2'],
+    install_requires=requirements,
     zip_safe=True,
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
I realized that updating the requirements file doesn't help since we still pull in >= tornado 4.2 in the setup file. I think we can solve this potential issue going forward by making requirements.txt the source of truth for install_requires. Explicitly supporting tornado >= 4.2 but less than 5.0 for now should allow closing of #32 and #31 I believe. 

@wallyqs 