### PR TITLE
Fix old iostream and flusher loop reconnection issues

### DIFF
--- a/nats/io/client.py
+++ b/nats/io/client.py
@@ -706,6 +706,9 @@ class Client(object):
       if self._ping_timer is not None and self._ping_timer.is_running():
         self._ping_timer.stop()
 
+      if self.io and not self.io.closed():
+        self.io.close()
+
       while True:
         try:
           yield self._schedule_primary_and_connect()

--- a/nats/io/client.py
+++ b/nats/io/client.py
@@ -337,8 +337,8 @@ class Client(object):
     yield self.send_command(pub_cmd)
 
   @tornado.gen.coroutine
-  def _flush_pending(self):
-    if not self.is_connected:
+  def _flush_pending(self, check_connected=True):
+    if not self.is_connected and check_connected:
       return
     yield self._flush_queue.put(None)
 
@@ -699,7 +699,9 @@ class Client(object):
 
     if not self.options["allow_reconnect"]:
       self._process_disconnect()
+      yield self._end_flusher_loop()
       return
+
     if self.is_connected:
       self._status = Client.RECONNECTING
 
@@ -708,6 +710,8 @@ class Client(object):
 
       if self.io and not self.io.closed():
         self.io.close()
+
+      yield self._end_flusher_loop()
 
       while True:
         try:
@@ -907,6 +911,16 @@ class Client(object):
         if self._error_cb is not None and not self.is_reconnecting:
           self._error_cb(e)
         yield self._unbind()
+
+  @tornado.gen.coroutine
+  def _end_flusher_loop(self):
+    """
+    Let flusher_loop coroutine quit - useful when disconnecting.
+    """
+    if not self.is_connected or self.is_connecting or self.io.closed():
+      if self._flush_queue.empty():
+        self._flush_pending(check_connected=False)
+      yield tornado.gen.moment
 
 class Subscription():
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -337,6 +337,25 @@ class ClientTest(tornado.testing.AsyncTestCase):
           self.assertTrue(client.closed_cb_called)
 
      @tornado.testing.gen_test
+     def test_iostream_closed_on_unbind(self):
+          nc = Client()
+          yield nc.connect(io_loop=self.io_loop)
+          self.assertTrue(nc.is_connected)
+          self.assertEqual(nc.stats['reconnects'], 0)
+          old_io = nc.io
+          # Unbind and reconnect.
+          yield nc._unbind()
+          self.assertTrue(nc.is_connected)
+          self.assertEqual(nc.stats['reconnects'], 1)
+          self.assertTrue(old_io.closed())
+          self.assertFalse(nc.io.closed())
+          # Unbind, but don't reconnect.
+          nc.options["allow_reconnect"] = False
+          yield nc._unbind()
+          self.assertFalse(nc.is_connected)
+          self.assertTrue(nc.io.closed())
+
+     @tornado.testing.gen_test
      def test_subscribe(self):
           nc = Client()
           options = {

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -356,6 +356,42 @@ class ClientTest(tornado.testing.AsyncTestCase):
           self.assertTrue(nc.io.closed())
 
      @tornado.testing.gen_test
+     def test_flusher_exits_on_unbind(self):
+
+          class FlusherClient(Client):
+               def __init__(self, *args, **kwargs):
+                    super(FlusherClient, self).__init__(*args, **kwargs)
+                    self.flushers_running = {}
+
+               @tornado.gen.coroutine
+               def _flusher_loop(self):
+                    flusher_id = len(self.flushers_running)
+                    self.flushers_running.update({flusher_id: True})
+                    yield super(FlusherClient, self)._flusher_loop()
+                    self.flushers_running.update({flusher_id: False})
+
+          nc = FlusherClient()
+          yield nc.connect(io_loop=self.io_loop)
+          self.assertTrue(nc.is_connected)
+          self.assertEqual(len(nc.flushers_running), 1)
+          self.assertTrue(nc.flushers_running[0])
+          # Unbind and reconnect.
+          yield nc._unbind()
+          self.assertTrue(nc.is_connected)
+          self.assertEqual(len(nc.flushers_running), 2)
+          self.assertFalse(nc.flushers_running[0])
+          self.assertTrue(nc.flushers_running[1])
+          # Unbind, but don't reconnect.
+          nc.options["allow_reconnect"] = False
+          yield nc._unbind()
+          yield tornado.gen.sleep(0.1)
+          self.assertFalse(nc.is_connected)
+          self.assertTrue(nc.io.closed())
+          self.assertEqual(len(nc.flushers_running), 2)
+          self.assertFalse(nc.flushers_running[0])
+          self.assertFalse(nc.flushers_running[1])
+
+     @tornado.testing.gen_test
      def test_subscribe(self):
           nc = Client()
           options = {


### PR DESCRIPTION
This addresses two issues noticeable when reconnecting.  This first is major, the second minor.

#### 1. Close iostream before reconnecting
If too many pings are outstanding, `_send_ping` calls `_unbind`.  If reconnecting is allowed, the client does reconnect, but the old iostream is not closed.  This results in 2 active connections to the NATS server.  After a while the 1st connection is kicked by the server because it is stale.  Unfortunately, this late closing of the first connection calls `_unbind` again, so we end up disconnecting the 2nd connection even though it was fine.  This reconnect-disconnect cycle continues every few minutes. 
 The fix is to close the iostream before reconnecting.

####  2. Allow flusher loop to exit when disconnecting
If the `_flusher_loop` is blocked waiting on the `_flush_queue` when we disconnect then the coroutine will just stay blocked there forever.  This isn't critical, but it is cleaner to allow the flusher loop to exit before spawning a new one - especially if we are reconnecting.

The `_read_loop` doesn't have this problem because it is blocked on an iostream read which raises an exception when the iostream is closed. That allows the read loop to exit.