### PR TITLE
Don't call error callback in read loop if connection was closed

### DIFF
--- a/nats/io/client.py
+++ b/nats/io/client.py
@@ -938,7 +938,7 @@ class Client(object):
                 yield self.io.read_bytes(DEFAULT_READ_CHUNK_SIZE, streaming_callback=self._ps.parse, partial=True)
             except tornado.iostream.StreamClosedError as e:
                 self._err = e
-                if self._error_cb is not None and not self.is_reconnecting:
+                if self._error_cb is not None and not self.is_reconnecting and not self.is_closed:
                     self._error_cb(e)
                 break
 


### PR DESCRIPTION
When closing the client, the underlying socket is also closed. The loop reading off that socket is left running, and logs the error it receives when the socket is closed. This error is misleading as the socket was closed on purpose by the user, so it shouldn't call the error callback.

@wallyqs 