### PR TITLE
Format code with google/yapf

### DIFF
--- a/benchmark/latency_perf.py
+++ b/benchmark/latency_perf.py
@@ -8,69 +8,76 @@ from nats.io.client import Client as NATS
 DEFAULT_ITERATIONS = 10000
 HASH_MODULO = 1000
 
+
 def show_usage():
-  message = """
+    message = """
 Usage: latency_perf [options]
 
 options:
   -n ITERATIONS                    Iterations to spec (default: 1000)
   -S SUBJECT                       Send subject (default: (test)
   """
-  print(message)
+    print(message)
+
 
 def show_usage_and_die():
-  show_usage()
-  sys.exit(1)
+    show_usage()
+    sys.exit(1)
+
 
 global received
 received = 0
 
+
 @tornado.gen.coroutine
 def main():
-  parser = argparse.ArgumentParser()
-  parser.add_argument('-n', '--iterations', default=DEFAULT_ITERATIONS, type=int)
-  parser.add_argument('-S', '--subject', default='test')
-  parser.add_argument('--servers', default=[], action='append')
-  args = parser.parse_args()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-n', '--iterations', default=DEFAULT_ITERATIONS, type=int)
+    parser.add_argument('-S', '--subject', default='test')
+    parser.add_argument('--servers', default=[], action='append')
+    args = parser.parse_args()
 
-  servers = args.servers
-  if len(args.servers) < 1:
-    servers = ["nats://127.0.0.1:4222"]
-  opts = { "servers": servers }
+    servers = args.servers
+    if len(args.servers) < 1:
+        servers = ["nats://127.0.0.1:4222"]
+    opts = {"servers": servers}
 
-  # Make sure we're connected to a server first...
-  nc = NATS()
-  try:
-    yield nc.connect(**opts)
-  except Exception, e:
-    sys.stderr.write("ERROR: {0}".format(e))
-    show_usage_and_die()
+    # Make sure we're connected to a server first...
+    nc = NATS()
+    try:
+        yield nc.connect(**opts)
+    except Exception, e:
+        sys.stderr.write("ERROR: {0}".format(e))
+        show_usage_and_die()
 
-  @tornado.gen.coroutine
-  def handler(msg):
-    yield nc.publish(msg.reply, "")
-  yield nc.subscribe(args.subject, cb=handler)
+    @tornado.gen.coroutine
+    def handler(msg):
+        yield nc.publish(msg.reply, "")
 
-  # Start the benchmark
-  start = time.time()
-  to_send = args.iterations
+    yield nc.subscribe(args.subject, cb=handler)
 
-  print("Sending {0} request/responses on [{1}]".format(
-      args.iterations, args.subject))
-  while to_send > 0:
-    to_send -= 1
-    if to_send == 0:
-      break
+    # Start the benchmark
+    start = time.time()
+    to_send = args.iterations
 
-    yield nc.timed_request(args.subject, "")
-    if (to_send % HASH_MODULO) == 0:
-      sys.stdout.write("+")
-      sys.stdout.flush()
+    print("Sending {0} request/responses on [{1}]".format(
+        args.iterations, args.subject))
+    while to_send > 0:
+        to_send -= 1
+        if to_send == 0:
+            break
 
-  duration = time.time() - start
-  ms = "%.3f" % ((duration/args.iterations) * 1000)
-  print("\nTest completed : {0} ms avg request/response latency".format(ms))
-  yield nc.close()
+        yield nc.timed_request(args.subject, "")
+        if (to_send % HASH_MODULO) == 0:
+            sys.stdout.write("+")
+            sys.stdout.flush()
+
+    duration = time.time() - start
+    ms = "%.3f" % ((duration / args.iterations) * 1000)
+    print("\nTest completed : {0} ms avg request/response latency".format(ms))
+    yield nc.close()
+
 
 if __name__ == '__main__':
-  tornado.ioloop.IOLoop.instance().run_sync(main)
+    tornado.ioloop.IOLoop.instance().run_sync(main)

--- a/benchmark/parser_perf.py
+++ b/benchmark/parser_perf.py
@@ -2,22 +2,22 @@ import cProfile as prof
 import tornado.gen
 from nats.protocol.parser import *
 
-class DummyNatsClient:
 
+class DummyNatsClient:
     def __init__(self):
         self._subs = {}
         self._pongs = []
         self._pings_outstanding = 0
         self._pongs_received = 0
-        self._server_info = {"max_payload": 1048576, "auth_required": False }
+        self._server_info = {"max_payload": 1048576, "auth_required": False}
         self.stats = {
-            'in_msgs':    0,
-            'out_msgs':   0,
-            'in_bytes':   0,
-            'out_bytes':  0,
+            'in_msgs': 0,
+            'out_msgs': 0,
+            'in_bytes': 0,
+            'out_bytes': 0,
             'reconnects': 0,
             'errors_received': 0
-            }
+        }
 
     @tornado.gen.coroutine
     def _send_command(self, cmd):
@@ -33,12 +33,13 @@ class DummyNatsClient:
 
     @tornado.gen.coroutine
     def _process_msg(self, sid, subject, reply, data):
-        self.stats['in_msgs']  += 1
+        self.stats['in_msgs'] += 1
         self.stats['in_bytes'] += len(data)
 
     @tornado.gen.coroutine
     def _process_err(self, err=None):
         pass
+
 
 def generate_msg(subject, nbytes, reply=""):
     msg = []
@@ -49,15 +50,18 @@ def generate_msg(subject, nbytes, reply=""):
     msg.append(b'r\n')
     return b''.join(msg)
 
+
 def parse_msgs(max_msgs=1, nbytes=1):
     buf = bytearray()
-    buf.extend(b''.join([generate_msg("foo", nbytes) for i in range(0, max_msgs)]))
+    buf.extend(b''.join(
+        [generate_msg("foo", nbytes) for i in range(0, max_msgs)]))
     print("--- buffer size: {0}".format(len(buf)))
     loop = tornado.ioloop.IOLoop.instance()
     ps = Parser(DummyNatsClient())
     ps.buf = buf
     loop.run_sync(ps.parse)
     print("--- stats: ", ps.nc.stats)
+
 
 if __name__ == '__main__':
 
@@ -74,7 +78,7 @@ if __name__ == '__main__':
         "parse_msgs(max_msgs=100000,  nbytes=8192)",
         "parse_msgs(max_msgs=10000,   nbytes=16384)",
         "parse_msgs(max_msgs=100000,  nbytes=16384)",
-        ]
+    ]
 
     for bench in benchs:
         print("=== {0}".format(bench))

--- a/benchmark/pub_perf.py
+++ b/benchmark/pub_perf.py
@@ -11,6 +11,7 @@ DEFAULT_MSG_SIZE = 16
 DEFAULT_BATCH_SIZE = 100
 HASH_MODULO = 1000
 
+
 def show_usage():
     message = """
 Usage: pub_perf [options]
@@ -23,9 +24,11 @@ options:
     """
     print(message)
 
+
 def show_usage_and_die():
     show_usage()
     sys.exit(1)
+
 
 @tornado.gen.coroutine
 def main():
@@ -45,7 +48,7 @@ def main():
     servers = args.servers
     if len(args.servers) < 1:
         servers = ["nats://127.0.0.1:4222"]
-    opts = { "servers": servers }
+    opts = {"servers": servers}
 
     # Make sure we're connected to a server first..
     nc = NATS()
@@ -78,11 +81,11 @@ def main():
     yield nc.flush()
 
     elapsed = time.time() - start
-    mbytes = "%.1f" % (((args.size * args.count)/elapsed) / (1024*1024))
+    mbytes = "%.1f" % (((args.size * args.count) / elapsed) / (1024 * 1024))
     print("\nTest completed : {0} msgs/sec ({1}) MB/sec\n".format(
-        args.count/elapsed,
-        mbytes))
+        args.count / elapsed, mbytes))
     yield nc.close()
+
 
 if __name__ == '__main__':
     tornado.ioloop.IOLoop.instance().run_sync(main)

--- a/benchmark/pub_sub_perf.py
+++ b/benchmark/pub_sub_perf.py
@@ -10,6 +10,7 @@ DEFAULT_MSG_SIZE = 16
 DEFAULT_BATCH_SIZE = 100
 HASH_MODULO = 1000
 
+
 def show_usage():
     message = """
 Usage: pub_sub_perf [options]
@@ -22,21 +23,27 @@ options:
     """
     print(message)
 
+
 def show_usage_and_die():
     show_usage()
     sys.exit(1)
 
+
 global received
 received = 0
+
 
 def close_cb():
     print("Closed connection to NATS")
 
+
 def disconnected_cb():
     print("Disconnected from NATS")
 
+
 def reconnected_cb():
     print("Reconnected to NATS")
+
 
 @tornado.gen.coroutine
 def main():
@@ -66,7 +73,7 @@ def main():
 
     # Make sure we're connected to a server first...
     nc = NATS()
-    try:    
+    try:
         yield nc.connect(**opts)
     except Exception, e:
         sys.stderr.write("ERROR: {0}".format(e))
@@ -102,12 +109,13 @@ def main():
     yield nc.flush()
 
     elapsed = time.time() - start
-    mbytes = "%.1f" % (((args.size * args.count)/elapsed) / (1024*1024))
+    mbytes = "%.1f" % (((args.size * args.count) / elapsed) / (1024 * 1024))
     print("\nTest completed : {0} msgs/sec sent ({1}) MB/sec\n".format(
-        args.count/elapsed,
-        mbytes))
-    print("Received {0} messages ({1} msgs/sec)".format(received, received/elapsed))
+        args.count / elapsed, mbytes))
+    print("Received {0} messages ({1} msgs/sec)".format(
+        received, received / elapsed))
     yield nc.close()
+
 
 if __name__ == '__main__':
     tornado.ioloop.IOLoop.instance().run_sync(main)

--- a/benchmark/sub_perf.py
+++ b/benchmark/sub_perf.py
@@ -10,6 +10,7 @@ DEFAULT_MSG_SIZE = 16
 DEFAULT_BATCH_SIZE = 100
 HASH_MODULO = 1000
 
+
 def show_usage():
     message = """
 Usage: sub_perf [options]
@@ -21,12 +22,15 @@ options:
     """
     print(message)
 
+
 def show_usage_and_die():
     show_usage()
     sys.exit(1)
 
+
 global received
 received = 0
+
 
 @tornado.gen.coroutine
 def main():
@@ -40,7 +44,7 @@ def main():
     servers = args.servers
     if len(args.servers) < 1:
         servers = ["nats://127.0.0.1:4222"]
-    opts = { "servers": servers }
+    opts = {"servers": servers}
 
     # Make sure we're connected to a server first...
     nc = NATS()
@@ -66,14 +70,16 @@ def main():
     elif args.subtype == 'async':
         yield nc.subscribe_async(args.subject, cb=handler)
     else:
-        sys.stderr.write("ERROR: Unsupported type of subscription {0}".format(e))
+        sys.stderr.write(
+            "ERROR: Unsupported type of subscription {0}".format(e))
         show_usage_and_die()
 
     # Start the benchmark
     start = time.time()
     to_send = args.count
 
-    print("Waiting for {0} messages on [{1}]...".format(args.count, args.subject))
+    print("Waiting for {0} messages on [{1}]...".format(
+        args.count, args.subject))
     while received < args.count:
         # Minimal pause in between batches sent to server
         yield tornado.gen.sleep(0.1)
@@ -82,9 +88,12 @@ def main():
     yield nc.flush()
 
     elapsed = time.time() - start
-    print("\nTest completed : {0} msgs/sec sent \n".format(args.count/elapsed))
-    print("Received {0} messages ({1} msgs/sec)".format(received, received/elapsed))
+    print("\nTest completed : {0} msgs/sec sent \n".format(
+        args.count / elapsed))
+    print("Received {0} messages ({1} msgs/sec)".format(
+        received, received / elapsed))
     yield nc.close()
+
 
 if __name__ == '__main__':
     tornado.ioloop.IOLoop.instance().run_sync(main)

--- a/examples/advanced-example.py
+++ b/examples/advanced-example.py
@@ -18,19 +18,21 @@ import tornado.gen
 import time
 from nats.io import Client as NATS
 
+
 @tornado.gen.coroutine
 def main():
     nc = NATS()
 
     # Set pool servers in the cluster and give a name to the client.
     options = {
-        "name": "worker",
+        "name":
+        "worker",
         "servers": [
             "nats://secret:pass@127.0.0.1:4222",
             "nats://secret:pass@127.0.0.1:4223",
             "nats://secret:pass@127.0.0.1:4224"
-            ]
-        }
+        ]
+    }
 
     # Explicitly set loop to use for the reactor.
     options["io_loop"] = tornado.ioloop.IOLoop.instance()
@@ -65,7 +67,8 @@ def main():
         delta = sent - received
 
         if delta > 2000:
-            print("Waiting... Sent: {0}, Received: {1}, Delta: {2}".format(sent, received, delta))
+            print("Waiting... Sent: {0}, Received: {1}, Delta: {2}".format(
+                sent, received, delta))
             yield tornado.gen.sleep(1)
 
         if nc.stats["reconnects"] > 10:
@@ -73,6 +76,7 @@ def main():
 
         for i in range(1000):
             yield nc.publish("discover", "ping")
+
 
 if __name__ == '__main__':
     tornado.ioloop.IOLoop.instance().run_sync(main)

--- a/examples/clustered-example.py
+++ b/examples/clustered-example.py
@@ -19,6 +19,7 @@ from datetime import timedelta
 from nats.io.client import Client as NATS
 from nats.io.errors import ErrConnectionClosed
 
+
 @tornado.gen.coroutine
 def main():
     nc = NATS()
@@ -30,8 +31,8 @@ def main():
             "nats://secret1:pass1@127.0.0.1:4222",
             "nats://secret2:pass2@127.0.0.1:4223",
             "nats://secret3:pass3@127.0.0.1:4224"
-            ]
-        }
+        ]
+    }
 
     # Error callback takes the error type as param.
     def error_cb(e):
@@ -50,7 +51,7 @@ def main():
     # protocol error message from the server.
     options["error_cb"] = error_cb
 
-    # Called when we are not connected anymore to the NATS cluster.    
+    # Called when we are not connected anymore to the NATS cluster.
     options["close_cb"] = close_cb
 
     # Called whenever we become disconnected from a NATS server.
@@ -77,6 +78,7 @@ def main():
         yield nc.publish("ping", "ping")
     except ErrConnectionClosed:
         print("No longer connected to NATS cluster.")
+
 
 if __name__ == '__main__':
     tornado.ioloop.IOLoop.instance().run_sync(main)

--- a/examples/example.py
+++ b/examples/example.py
@@ -17,15 +17,16 @@ import tornado.ioloop
 import tornado.gen
 import time
 from datetime import datetime
-from nats.io.utils  import new_inbox
+from nats.io.utils import new_inbox
 from nats.io.client import Client as NATS
+
 
 @tornado.gen.coroutine
 def main():
     nc = NATS()
 
     # Establish connection to the server.
-    options = { "verbose": True, "servers": ["nats://127.0.0.1:4222"] }
+    options = {"verbose": True, "servers": ["nats://127.0.0.1:4222"]}
     yield nc.connect(**options)
 
     def discover(msg=None):
@@ -52,7 +53,8 @@ def main():
 
     try:
         # Expect a single request and timeout after 500 ms
-        response = yield nc.timed_request("help", "Hi, need help!", timeout=0.500)
+        response = yield nc.timed_request(
+            "help", "Hi, need help!", timeout=0.500)
         print("[Response]: %s" % response.data)
     except tornado.gen.TimeoutError, e:
         print("Timeout! Need to retry...")
@@ -78,6 +80,7 @@ def main():
         print("Latency: %d µs" % (end.microsecond - start.microsecond))
     except tornado.gen.TimeoutError, e:
         print("Timeout! Roundtrip too slow...")
+
 
 if __name__ == '__main__':
     tornado.ioloop.IOLoop.instance().run_sync(main)

--- a/examples/nats-pub/__main__.py
+++ b/examples/nats-pub/__main__.py
@@ -19,16 +19,21 @@ import time
 
 from nats.io.client import Client as NATS
 
+
 def show_usage():
-  print("nats-pub SUBJECT [-d DATA] [-s SERVER]")
-  print("")
-  print("Example:")
-  print("")
-  print("nats-pub hello -d world -s nats://127.0.0.1:4222 -s nats://127.0.0.1:4223")
+    print("nats-pub SUBJECT [-d DATA] [-s SERVER]")
+    print("")
+    print("Example:")
+    print("")
+    print(
+        "nats-pub hello -d world -s nats://127.0.0.1:4222 -s nats://127.0.0.1:4223"
+    )
+
 
 def show_usage_and_die():
-  show_usage()
-  sys.exit(1)
+    show_usage()
+    sys.exit(1)
+
 
 @tornado.gen.coroutine
 def main():
@@ -43,18 +48,19 @@ def main():
 
     nc = NATS()
     try:
-      servers = args.servers
-      if len(args.servers) < 1:
-        servers = ["nats://127.0.0.1:4222"]
+        servers = args.servers
+        if len(args.servers) < 1:
+            servers = ["nats://127.0.0.1:4222"]
 
-      opts = { "servers": servers }
-      yield nc.connect(**opts)
-      yield nc.publish(args.subject, args.data)
-      yield nc.flush()
-      print("Published to '{0}'".format(args.subject))
+        opts = {"servers": servers}
+        yield nc.connect(**opts)
+        yield nc.publish(args.subject, args.data)
+        yield nc.flush()
+        print("Published to '{0}'".format(args.subject))
     except Exception, e:
-      print(e)
-      show_usage_and_die()
+        print(e)
+        show_usage_and_die()
+
 
 if __name__ == '__main__':
     tornado.ioloop.IOLoop.instance().run_sync(main)

--- a/examples/nats-sub/__main__.py
+++ b/examples/nats-sub/__main__.py
@@ -19,12 +19,15 @@ import time
 
 from nats.io.client import Client as NATS
 
+
 def show_usage():
-  print("nats-sub SUBJECT [-s SERVER] [-q QUEUE]")
+    print("nats-sub SUBJECT [-s SERVER] [-q QUEUE]")
+
 
 def show_usage_and_die():
-  show_usage()
-  sys.exit(1)
+    show_usage()
+    sys.exit(1)
+
 
 @tornado.gen.coroutine
 def main():
@@ -43,9 +46,9 @@ def main():
     nc = NATS()
     servers = args.servers
     if len(args.servers) < 1:
-      servers = ["nats://127.0.0.1:4222"]
+        servers = ["nats://127.0.0.1:4222"]
 
-    opts = { "servers": servers }
+    opts = {"servers": servers}
     yield nc.connect(**opts)
 
     def handler(msg):
@@ -54,6 +57,7 @@ def main():
     print("Subscribed to '{0}'".format(args.subject))
     future = nc.subscribe(args.subject, args.queue, handler)
     sid = future.result()
+
 
 if __name__ == '__main__':
     main()

--- a/examples/tls.py
+++ b/examples/tls.py
@@ -18,8 +18,9 @@ import tornado.gen
 import time
 import ssl
 from datetime import datetime
-from nats.io.utils  import new_inbox
+from nats.io.utils import new_inbox
 from nats.io.client import Client as NATS
+
 
 @tornado.gen.coroutine
 def main():
@@ -33,10 +34,10 @@ def main():
         "tls": {
             "cert_reqs": ssl.CERT_REQUIRED,
             "ca_certs": "./tests/configs/certs/ca.pem",
-            "keyfile":  "./tests/configs/certs/client-key.pem",
+            "keyfile": "./tests/configs/certs/client-key.pem",
             "certfile": "./tests/configs/certs/client-cert.pem"
-          }
         }
+    }
     yield nc.connect(**options)
 
     def discover(msg=None):
@@ -63,7 +64,8 @@ def main():
 
     try:
         # Expect a single request and timeout after 500 ms
-        response = yield nc.timed_request("help", "Hi, need help!", timeout=0.500)
+        response = yield nc.timed_request(
+            "help", "Hi, need help!", timeout=0.500)
         print("[Response]: %s" % response.data)
     except tornado.gen.TimeoutError, e:
         print("Timeout! Need to retry...")
@@ -89,6 +91,7 @@ def main():
         print("Latency: %d µs" % (end.microsecond - start.microsecond))
     except tornado.gen.TimeoutError, e:
         print("Timeout! Roundtrip too slow...")
+
 
 if __name__ == '__main__':
     tornado.ioloop.IOLoop.instance().run_sync(main)

--- a/nats/__init__.py
+++ b/nats/__init__.py
@@ -12,5 +12,5 @@
 # limitations under the License.
 #
 
-__version__  = b'0.7.0'
-__lang__     = b'python2'
+__version__ = b'0.7.0'
+__lang__ = b'python2'

--- a/nats/io/client.py
+++ b/nats/io/client.py
@@ -33,42 +33,43 @@ from nats.io.nuid import NUID
 from nats.protocol.parser import *
 
 CONNECT_PROTO = b'{0} {1}{2}'
-PUB_PROTO     = b'{0} {1} {2} {3} {4}{5}{6}'
-SUB_PROTO     = b'{0} {1} {2} {3}{4}'
-UNSUB_PROTO   = b'{0} {1} {2}{3}'
+PUB_PROTO = b'{0} {1} {2} {3} {4}{5}{6}'
+SUB_PROTO = b'{0} {1} {2} {3}{4}'
+UNSUB_PROTO = b'{0} {1} {2}{3}'
 
-INFO_OP       = b'INFO'
-CONNECT_OP    = b'CONNECT'
-PUB_OP        = b'PUB'
-MSG_OP        = b'MSG'
-SUB_OP        = b'SUB'
-UNSUB_OP      = b'UNSUB'
-PING_OP       = b'PING'
-PONG_OP       = b'PONG'
-OK_OP         = b'+OK'
-ERR_OP        = b'-ERR'
-_CRLF_        = b'\r\n'
-_SPC_         = b' '
-_EMPTY_       = b''
+INFO_OP = b'INFO'
+CONNECT_OP = b'CONNECT'
+PUB_OP = b'PUB'
+MSG_OP = b'MSG'
+SUB_OP = b'SUB'
+UNSUB_OP = b'UNSUB'
+PING_OP = b'PING'
+PONG_OP = b'PONG'
+OK_OP = b'+OK'
+ERR_OP = b'-ERR'
+_CRLF_ = b'\r\n'
+_SPC_ = b' '
+_EMPTY_ = b''
 
-PING_PROTO    = b'{0}{1}'.format(PING_OP, _CRLF_)
-PONG_PROTO    = b'{0}{1}'.format(PONG_OP, _CRLF_)
+PING_PROTO = b'{0}{1}'.format(PING_OP, _CRLF_)
+PONG_PROTO = b'{0}{1}'.format(PONG_OP, _CRLF_)
 
 # Defaults
-DEFAULT_PING_INTERVAL     = 120 # seconds
-MAX_OUTSTANDING_PINGS     = 2
-MAX_RECONNECT_ATTEMPTS    = 60
-RECONNECT_TIME_WAIT       = 2   # seconds
-DEFAULT_CONNECT_TIMEOUT   = 2   # seconds
+DEFAULT_PING_INTERVAL = 120  # seconds
+MAX_OUTSTANDING_PINGS = 2
+MAX_RECONNECT_ATTEMPTS = 60
+RECONNECT_TIME_WAIT = 2  # seconds
+DEFAULT_CONNECT_TIMEOUT = 2  # seconds
 
-DEFAULT_READ_BUFFER_SIZE  = 1024 * 1024 * 10
+DEFAULT_READ_BUFFER_SIZE = 1024 * 1024 * 10
 DEFAULT_WRITE_BUFFER_SIZE = None
-DEFAULT_READ_CHUNK_SIZE   = 32768 * 2
-DEFAULT_PENDING_SIZE      = 1024 * 1024
-DEFAULT_MAX_PAYLOAD_SIZE  = 1048576
+DEFAULT_READ_CHUNK_SIZE = 32768 * 2
+DEFAULT_PENDING_SIZE = 1024 * 1024
+DEFAULT_MAX_PAYLOAD_SIZE = 1048576
 
 PROTOCOL = 1
 INBOX_PREFIX = bytearray(b'_INBOX.')
+
 
 class Client(object):
     """
@@ -101,10 +102,10 @@ class Client(object):
         self._pending_size = 0
         self._loop = None
         self.stats = {
-            'in_msgs':    0,
-            'out_msgs':   0,
-            'in_bytes':   0,
-            'out_bytes':  0,
+            'in_msgs': 0,
+            'out_msgs': 0,
+            'in_bytes': 0,
+            'out_bytes': 0,
             'reconnects': 0,
             'errors_received': 0
         }
@@ -154,8 +155,7 @@ class Client(object):
                 connect_timeout=DEFAULT_CONNECT_TIMEOUT,
                 max_reconnect_attempts=MAX_RECONNECT_ATTEMPTS,
                 reconnect_time_wait=RECONNECT_TIME_WAIT,
-                tls=None
-                ):
+                tls=None):
         """
         Establishes a connection to a NATS server.
 
@@ -213,8 +213,10 @@ class Client(object):
                 # Check when was the last attempt and back off before reconnecting
                 if s.last_attempt is not None:
                     now = time.time()
-                    if (now - s.last_attempt) < self.options["reconnect_time_wait"]:
-                        yield tornado.gen.sleep(self.options["reconnect_time_wait"])
+                    if (now - s.last_attempt
+                        ) < self.options["reconnect_time_wait"]:
+                        yield tornado.gen.sleep(
+                            self.options["reconnect_time_wait"])
 
                 # Mark that we have attempted to connect
                 s.reconnects += 1
@@ -249,9 +251,7 @@ class Client(object):
 
         # Prepare the ping pong interval.
         self._ping_timer = tornado.ioloop.PeriodicCallback(
-            self._send_ping,
-            self.options["ping_interval"] * 1000
-        )
+            self._send_ping, self.options["ping_interval"] * 1000)
         self._ping_timer.start()
 
     @tornado.gen.coroutine
@@ -275,8 +275,7 @@ class Client(object):
         # Connect to server with a deadline
         future = self.io.connect((s.uri.hostname, s.uri.port))
         yield tornado.gen.with_timeout(
-            timedelta(seconds=self.options["connect_timeout"]),
-            future)
+            timedelta(seconds=self.options["connect_timeout"]), future)
 
     @tornado.gen.coroutine
     def _send_ping(self, future=None):
@@ -299,10 +298,10 @@ class Client(object):
 
         '''
         options = {
-            "verbose":  self.options["verbose"],
+            "verbose": self.options["verbose"],
             "pedantic": self.options["pedantic"],
-            "lang":     __lang__,
-            "version":  __version__,
+            "lang": __lang__,
+            "version": __version__,
             "protocol": PROTOCOL
         }
         if "auth_required" in self._server_info:
@@ -337,8 +336,11 @@ class Client(object):
     @tornado.gen.coroutine
     def _publish(self, subject, reply, payload, payload_size):
         payload_size_bytes = ("%d" % payload_size).encode()
-        pub_cmd = b''.join([PUB_OP, _SPC_, subject.encode(
-        ), _SPC_, reply, _SPC_, payload_size_bytes, _CRLF_, payload, _CRLF_])
+        pub_cmd = b''.join([
+            PUB_OP, _SPC_,
+            subject.encode(), _SPC_, reply, _SPC_, payload_size_bytes, _CRLF_,
+            payload, _CRLF_
+        ])
         self.stats['out_msgs'] += 1
         self.stats['out_bytes'] += payload_size
         yield self.send_command(pub_cmd)
@@ -400,7 +402,8 @@ class Client(object):
         future = tornado.concurrent.Future()
         yield self._send_ping(future)
         try:
-            result = yield tornado.gen.with_timeout(timedelta(seconds=timeout), future)
+            result = yield tornado.gen.with_timeout(
+                timedelta(seconds=timeout), future)
         except tornado.gen.TimeoutError:
             # Set the future to False so it can be ignored in _process_pong.
             future.set_result(False)
@@ -448,14 +451,22 @@ class Client(object):
         next_inbox.extend(self._nuid.next())
         inbox = str(next_inbox)
         future = tornado.concurrent.Future()
-        sid = yield self.subscribe(subject=inbox, queue=_EMPTY_, cb=None, future=future, max_msgs=1)
+        sid = yield self.subscribe(
+            subject=inbox, queue=_EMPTY_, cb=None, future=future, max_msgs=1)
         yield self.auto_unsubscribe(sid, 1)
         yield self.publish_request(subject, inbox, payload)
-        msg = yield tornado.gen.with_timeout(timedelta(seconds=timeout), future)
+        msg = yield tornado.gen.with_timeout(
+            timedelta(seconds=timeout), future)
         raise tornado.gen.Return(msg)
 
     @tornado.gen.coroutine
-    def subscribe(self, subject="", queue="", cb=None, future=None, max_msgs=0, is_async=False):
+    def subscribe(self,
+                  subject="",
+                  queue="",
+                  cb=None,
+                  future=None,
+                  max_msgs=0,
+                  is_async=False):
         """
         Sends a SUB command to the server. Takes a queue parameter which can be used
         in case of distributed queues or left empty if it is not the case, and a callback
@@ -521,8 +532,11 @@ class Client(object):
         """
         Generates a SUB command given a Subscription and the subject sequence id.
         """
-        sub_cmd = b''.join([SUB_OP, _SPC_, sub.subject.encode(
-        ), _SPC_, sub.queue.encode(), _SPC_, ("%d" % ssid).encode(), _CRLF_])
+        sub_cmd = b''.join([
+            SUB_OP, _SPC_,
+            sub.subject.encode(), _SPC_,
+            sub.queue.encode(), _SPC_, ("%d" % ssid).encode(), _CRLF_
+        ])
         yield self.send_command(sub_cmd)
         yield self._flush_pending()
 
@@ -597,7 +611,8 @@ class Client(object):
             else:
                 # Call it and take the possible future in the loop.
                 maybe_future = sub.cb(msg)
-                if maybe_future is not None and type(maybe_future) is tornado.concurrent.Future:
+                if maybe_future is not None and type(
+                        maybe_future) is tornado.concurrent.Future:
                     yield maybe_future
         elif sub.future is not None:
             sub.future.set_result(msg)
@@ -629,9 +644,7 @@ class Client(object):
             # Rewrap using a TLS connection, can't do handshake on connect
             # as the socket is non blocking.
             self._socket = ssl.wrap_socket(
-                self._socket,
-                do_handshake_on_connect=False,
-                **tls_opts)
+                self._socket, do_handshake_on_connect=False, **tls_opts)
 
             # Use the TLS stream instead from now
             self.io = tornado.iostream.SSLIOStream(
@@ -653,16 +666,18 @@ class Client(object):
         yield self.io.write(PING_PROTO)
 
         # FIXME: Add readline timeout for these.
-        next_op = yield self.io.read_until(_CRLF_, max_bytes=MAX_CONTROL_LINE_SIZE)
+        next_op = yield self.io.read_until(
+            _CRLF_, max_bytes=MAX_CONTROL_LINE_SIZE)
         if self.options["verbose"] and OK_OP in next_op:
-            next_op = yield self.io.read_until(_CRLF_, max_bytes=MAX_CONTROL_LINE_SIZE)
+            next_op = yield self.io.read_until(
+                _CRLF_, max_bytes=MAX_CONTROL_LINE_SIZE)
         if ERR_OP in next_op:
             err_line = next_op.decode()
             _, err_msg = err_line.split(_SPC_, 1)
             # FIXME: Maybe handling could be more special here,
             # checking for ErrAuthorization for example.
             # yield from self._process_err(err_msg)
-            raise NatsError("nats: "+err_msg.rstrip('\r\n'))
+            raise NatsError("nats: " + err_msg.rstrip('\r\n'))
 
         if PONG_PROTO in next_op:
             self._status = Client.CONNECTED
@@ -714,7 +729,9 @@ class Client(object):
 
         s = None
         for server in self._server_pool:
-            if self.options["max_reconnect_attempts"] > 0 and (server.reconnects > self.options["max_reconnect_attempts"]):
+            if self.options["max_reconnect_attempts"] > 0 and (
+                    server.reconnects >
+                    self.options["max_reconnect_attempts"]):
                 continue
             else:
                 s = server
@@ -780,14 +797,13 @@ class Client(object):
 
             # Replay all the subscriptions in case there were some.
             for ssid, sub in self._subs.items():
-                sub_cmd = SUB_PROTO.format(
-                    SUB_OP, sub.subject, sub.queue, ssid, _CRLF_)
+                sub_cmd = SUB_PROTO.format(SUB_OP, sub.subject, sub.queue,
+                                           ssid, _CRLF_)
                 yield self.io.write(sub_cmd)
 
             # Restart the ping pong interval callback.
             self._ping_timer = tornado.ioloop.PeriodicCallback(
-                self._send_ping,
-                self.options["ping_interval"] * 1000)
+                self._send_ping, self.options["ping_interval"] * 1000)
             self._ping_timer.start()
             self._err = None
             self._pings_outstanding = 0
@@ -820,8 +836,10 @@ class Client(object):
             # Check when was the last attempt and back off before reconnecting
             if s.last_attempt is not None:
                 now = time.time()
-                if (now - s.last_attempt) < self.options["reconnect_time_wait"]:
-                    yield tornado.gen.sleep(self.options["reconnect_time_wait"])
+                if (now -
+                        s.last_attempt) < self.options["reconnect_time_wait"]:
+                    yield tornado.gen.sleep(
+                        self.options["reconnect_time_wait"])
 
             s.reconnects += 1
             s.last_attempt = time.time()
@@ -942,7 +960,10 @@ class Client(object):
                 break
 
             try:
-                yield self.io.read_bytes(DEFAULT_READ_CHUNK_SIZE, streaming_callback=self._ps.parse, partial=True)
+                yield self.io.read_bytes(
+                    DEFAULT_READ_CHUNK_SIZE,
+                    streaming_callback=self._ps.parse,
+                    partial=True)
             except tornado.iostream.StreamClosedError as e:
                 self._err = e
                 if self._error_cb is not None and not self.is_reconnecting and not self.is_closed:
@@ -963,7 +984,8 @@ class Client(object):
                 yield self._flush_queue.get()
 
                 # Check whether we should bail first
-                if not self.is_connected or self.is_connecting or self.io.closed():
+                if not self.is_connected or self.is_connecting or self.io.closed(
+                ):
                     break
 
                 # Flush only when we actually have something in buffer...
@@ -998,15 +1020,15 @@ class Client(object):
 
 
 class Subscription():
-
-    def __init__(self,
-                 subject='',
-                 queue='',
-                 cb=None,
-                 is_async=False,
-                 future=None,
-                 max_msgs=0,
-                 ):
+    def __init__(
+            self,
+            subject='',
+            queue='',
+            cb=None,
+            is_async=False,
+            future=None,
+            max_msgs=0,
+    ):
         self.subject = subject
         self.queue = queue
         self.cb = cb
@@ -1017,13 +1039,13 @@ class Subscription():
 
 
 class Msg(object):
-
-    def __init__(self,
-                 subject='',
-                 reply='',
-                 data=b'',
-                 sid=0,
-                 ):
+    def __init__(
+            self,
+            subject='',
+            reply='',
+            data=b'',
+            sid=0,
+    ):
         self.subject = subject
         self.reply = reply
         self.data = data

--- a/nats/io/errors.py
+++ b/nats/io/errors.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 """
 Exported errors which can be thrown by the NATS client.
 """

--- a/nats/io/nuid.py
+++ b/nats/io/nuid.py
@@ -16,14 +16,15 @@ from random import Random, SystemRandom
 from sys import maxsize as MaxInt
 
 DIGITS = b'0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
-BASE          = 62
+BASE = 62
 PREFIX_LENGTH = 12
-SEQ_LENGTH    = 10
-TOTAL_LENGTH  = PREFIX_LENGTH + SEQ_LENGTH
-MAX_SEQ       = BASE**10
-MIN_INC       = 33
-MAX_INC       = 333
+SEQ_LENGTH = 10
+TOTAL_LENGTH = PREFIX_LENGTH + SEQ_LENGTH
+MAX_SEQ = BASE**10
+MIN_INC = 33
+MAX_INC = 333
 INC = MAX_INC - MIN_INC
+
 
 class NUID(object):
     """
@@ -57,7 +58,8 @@ class NUID(object):
         return prefix
 
     def randomize_prefix(self):
-        random_bytes = (self._srand.getrandbits(8) for i in range(PREFIX_LENGTH))
+        random_bytes = (self._srand.getrandbits(8)
+                        for i in range(PREFIX_LENGTH))
         self._prefix = bytearray(DIGITS[c % BASE] for c in random_bytes)
 
     def reset_sequential(self):

--- a/nats/io/utils.py
+++ b/nats/io/utils.py
@@ -29,9 +29,11 @@ def new_inbox():
     Generates a unique _INBOX subject which can be used
     for publishing and receiving events.
     """
-    return ''.join([INBOX_PREFIX,
-                    hex_rand(0x10),
-                    hex_rand(0x10),
-                    hex_rand(0x10),
-                    hex_rand(0x10),
-                    hex_rand(0x24)])
+    return ''.join([
+        INBOX_PREFIX,
+        hex_rand(0x10),
+        hex_rand(0x10),
+        hex_rand(0x10),
+        hex_rand(0x10),
+        hex_rand(0x24)
+    ])

--- a/nats/protocol/parser.py
+++ b/nats/protocol/parser.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 """
 NATS network protocol parser.
 """
@@ -19,44 +18,45 @@ NATS network protocol parser.
 import re
 import tornado.gen
 
-MSG_RE  = re.compile(b'\AMSG\s+([^\s]+)\s+([^\s]+)\s+(([^\s]+)[^\S\r\n]+)?(\d+)\r\n')
-OK_RE   = re.compile(b'\A\+OK\s*\r\n')
-ERR_RE  = re.compile(b'\A-ERR\s+(\'.+\')?\r\n')
+MSG_RE = re.compile(
+    b'\AMSG\s+([^\s]+)\s+([^\s]+)\s+(([^\s]+)[^\S\r\n]+)?(\d+)\r\n')
+OK_RE = re.compile(b'\A\+OK\s*\r\n')
+ERR_RE = re.compile(b'\A-ERR\s+(\'.+\')?\r\n')
 PING_RE = re.compile(b'\APING\s*\r\n')
 PONG_RE = re.compile(b'\APONG\s*\r\n')
 INFO_RE = re.compile(b'\AINFO\s+([^\r\n]+)\r\n')
 
-INFO_OP     = b'INFO'
-CONNECT_OP  = b'CONNECT'
-PUB_OP      = b'PUB'
-MSG_OP      = b'MSG'
-SUB_OP      = b'SUB'
-UNSUB_OP    = b'UNSUB'
-PING_OP     = b'PING'
-PONG_OP     = b'PONG'
-OK_OP       = b'+OK'
-ERR_OP      = b'-ERR'
-MSG_END     = b'\n'
-_CRLF_      = b'\r\n'
-_SPC_       = b' '
+INFO_OP = b'INFO'
+CONNECT_OP = b'CONNECT'
+PUB_OP = b'PUB'
+MSG_OP = b'MSG'
+SUB_OP = b'SUB'
+UNSUB_OP = b'UNSUB'
+PING_OP = b'PING'
+PONG_OP = b'PONG'
+OK_OP = b'+OK'
+ERR_OP = b'-ERR'
+MSG_END = b'\n'
+_CRLF_ = b'\r\n'
+_SPC_ = b' '
 
-OK          = OK_OP + _CRLF_
-PING        = PING_OP + _CRLF_
-PONG        = PONG_OP + _CRLF_
-CRLF_SIZE   = len(_CRLF_)
-OK_SIZE     = len(OK)
-PING_SIZE   = len(PING)
-PONG_SIZE   = len(PONG)
+OK = OK_OP + _CRLF_
+PING = PING_OP + _CRLF_
+PONG = PONG_OP + _CRLF_
+CRLF_SIZE = len(_CRLF_)
+OK_SIZE = len(OK)
+PING_SIZE = len(PING)
+PONG_SIZE = len(PONG)
 MSG_OP_SIZE = len(MSG_OP)
 ERR_OP_SIZE = len(ERR_OP)
 
 # States
-AWAITING_CONTROL_LINE  = 1
-AWAITING_MSG_PAYLOAD   = 2
-MAX_CONTROL_LINE_SIZE  = 1024
+AWAITING_CONTROL_LINE = 1
+AWAITING_MSG_PAYLOAD = 2
+MAX_CONTROL_LINE_SIZE = 1024
+
 
 class Parser(object):
-
     def __init__(self, nc=None):
         self.nc = nc
         self.reset()
@@ -132,25 +132,27 @@ class Parser(object):
                 # a split buffer and need to gather more bytes,
                 # otherwise it would mean that there is an issue
                 # and we're getting malformed control lines.
-                if len(self.buf) < MAX_CONTROL_LINE_SIZE and _CRLF_ not in self.buf:
+                if len(self.buf
+                       ) < MAX_CONTROL_LINE_SIZE and _CRLF_ not in self.buf:
                     break
                 else:
                     raise ErrProtocol("nats: unknown protocol")
 
             elif self.state == AWAITING_MSG_PAYLOAD:
-                if len(self.buf) >= self.needed+CRLF_SIZE:
+                if len(self.buf) >= self.needed + CRLF_SIZE:
                     subject = self.msg_arg["subject"]
-                    sid     = self.msg_arg["sid"]
-                    reply   = self.msg_arg["reply"]
+                    sid = self.msg_arg["sid"]
+                    reply = self.msg_arg["reply"]
 
                     # Consume msg payload from buffer and set next parser state.
                     payload = bytes(self.buf[:self.needed])
-                    del self.buf[:self.needed+CRLF_SIZE]
+                    del self.buf[:self.needed + CRLF_SIZE]
                     self.state = AWAITING_CONTROL_LINE
                     yield self.nc._process_msg(sid, subject, reply, payload)
                 else:
                     # Wait until we have enough bytes in buffer.
                     break
+
 
 class ErrProtocol(Exception):
     def __str__(self):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ setup(
     name='nats-client',
     version=__version__,
     description='NATS client for Python 2',
-    long_description='Tornado based Python client for NATS, a lightweight, high-performance cloud native messaging system',
+    long_description=
+    'Tornado based Python client for NATS, a lightweight, high-performance cloud native messaging system',
     url='https://github.com/nats-io/python-nats',
     author='Waldemar Quevedo',
     author_email='wally@synadia.com',
@@ -21,5 +22,4 @@ setup(
     classifiers=[
         'Intended Audience :: Developers',
         'Programming Language :: Python',
-    ]
-)
+    ])

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -27,18 +27,18 @@ from nats import __lang__, __version__
 
 
 class Gnatsd(object):
-
-    def __init__(self,
-                 port=4222,
-                 user="",
-                 password="",
-                 timeout=0,
-                 http_port=8222,
-                 config_file=None,
-                 debug=False,
-                 conf=None,
-                 cluster_port=None,
-                 ):
+    def __init__(
+            self,
+            port=4222,
+            user="",
+            password="",
+            timeout=0,
+            http_port=8222,
+            config_file=None,
+            debug=False,
+            conf=None,
+            cluster_port=None,
+    ):
         self.port = port
         self.user = user
         self.password = password
@@ -120,19 +120,23 @@ class Gnatsd(object):
         if self.debug:
             if self.proc is None:
                 print(
-                    "[\031[0;33mDEBUG\033[0;0m] Failed to start server listening on port %d started." % self.port)
+                    "[\031[0;33mDEBUG\033[0;0m] Failed to start server listening on port %d started."
+                    % self.port)
             else:
                 print(
-                    "[\033[0;33mDEBUG\033[0;0m] Server listening on port %d started." % self.port)
+                    "[\033[0;33mDEBUG\033[0;0m] Server listening on port %d started."
+                    % self.port)
 
     def finish(self):
         if self.debug:
             print(
-                "[\033[0;33mDEBUG\033[0;0m] Server listening on %d will stop." % self.port)
+                "[\033[0;33mDEBUG\033[0;0m] Server listening on %d will stop."
+                % self.port)
 
         if self.debug and self.proc is None:
             print(
-                "[\033[0;31mDEBUG\033[0;0m] Failed terminating server listening on port %d" % self.port)
+                "[\033[0;31mDEBUG\033[0;0m] Failed terminating server listening on port %d"
+                % self.port)
         else:
             try:
                 self.proc.terminate()
@@ -140,11 +144,13 @@ class Gnatsd(object):
             except Exception as e:
                 if self.debug:
                     print(
-                        "[\033[0;33m WARN\033[0;0m] Could not stop server listening on %d. (%s)" % (self.port, e))
+                        "[\033[0;33m WARN\033[0;0m] Could not stop server listening on %d. (%s)"
+                        % (self.port, e))
 
             if self.debug:
                 print(
-                    "[\033[0;33mDEBUG\033[0;0m] Server listening on %d was stopped." % self.port)
+                    "[\033[0;33mDEBUG\033[0;0m] Server listening on %d was stopped."
+                    % self.port)
 
 
 class Log():
@@ -154,16 +160,16 @@ class Log():
 
     def persist(self, msg):
         if self.debug:
-            print("[\033[0;33mDEBUG\033[0;0m] Message received: [{0} {1} {2}].".format(
-                msg.subject, msg.reply, msg.data))
+            print(
+                "[\033[0;33mDEBUG\033[0;0m] Message received: [{0} {1} {2}].".
+                format(msg.subject, msg.reply, msg.data))
         self.records[msg.subject].append(msg)
 
 
 class ClientUtilsTest(unittest.TestCase):
-
     def setUp(self):
-        print("\n=== RUN {0}.{1}".format(
-            self.__class__.__name__, self._testMethodName))
+        print("\n=== RUN {0}.{1}".format(self.__class__.__name__,
+                                         self._testMethodName))
 
     def test_default_connect_command(self):
         nc = Client()
@@ -193,10 +199,9 @@ class ClientUtilsTest(unittest.TestCase):
 
 
 class ClientTest(tornado.testing.AsyncTestCase):
-
     def setUp(self):
-        print("\n=== RUN {0}.{1}".format(
-            self.__class__.__name__, self._testMethodName))
+        print("\n=== RUN {0}.{1}".format(self.__class__.__name__,
+                                         self._testMethodName))
         self.threads = []
         self.server_pool = []
 
@@ -232,10 +237,7 @@ class ClientTest(tornado.testing.AsyncTestCase):
     @tornado.testing.gen_test
     def test_connect_verbose(self):
         nc = Client()
-        options = {
-            "verbose": True,
-            "io_loop": self.io_loop
-        }
+        options = {"verbose": True, "io_loop": self.io_loop}
         yield nc.connect(**options)
 
         info_keys = nc._server_info.keys()
@@ -281,7 +283,6 @@ class ClientTest(tornado.testing.AsyncTestCase):
 
     @tornado.testing.gen_test(timeout=5)
     def test_connect_fails(self):
-
         class SampleClient():
             def __init__(self):
                 self.nc = Client()
@@ -303,7 +304,6 @@ class ClientTest(tornado.testing.AsyncTestCase):
 
     @tornado.testing.gen_test(timeout=5)
     def test_connect_fails_allow_reconnect(self):
-
         class SampleClient():
             def __init__(self):
                 self.nc = Client()
@@ -332,7 +332,6 @@ class ClientTest(tornado.testing.AsyncTestCase):
 
     @tornado.testing.gen_test(timeout=5)
     def test_connect_fails_allow_reconnect_forever_until_close(self):
-
         class SampleClient():
             def __init__(self):
                 self.nc = Client()
@@ -383,7 +382,6 @@ class ClientTest(tornado.testing.AsyncTestCase):
 
     @tornado.testing.gen_test
     def test_flusher_exits_on_unbind(self):
-
         class FlusherClient(Client):
             def __init__(self, *args, **kwargs):
                 super(FlusherClient, self).__init__(*args, **kwargs)
@@ -420,9 +418,7 @@ class ClientTest(tornado.testing.AsyncTestCase):
     @tornado.testing.gen_test
     def test_subscribe(self):
         nc = Client()
-        options = {
-            "io_loop": self.io_loop
-        }
+        options = {"io_loop": self.io_loop}
         yield nc.connect(**options)
         self.assertEqual(Client.CONNECTED, nc._status)
         info_keys = nc._server_info.keys()
@@ -434,7 +430,8 @@ class ClientTest(tornado.testing.AsyncTestCase):
         yield tornado.gen.sleep(0.5)
 
         http = tornado.httpclient.AsyncHTTPClient()
-        response = yield http.fetch('http://127.0.0.1:%d/connz' % self.server_pool[0].http_port)
+        response = yield http.fetch(
+            'http://127.0.0.1:%d/connz' % self.server_pool[0].http_port)
         result = json.loads(response.body)
         connz = result['connections'][0]
         self.assertEqual(2, connz['subscriptions'])
@@ -558,7 +555,8 @@ class ClientTest(tornado.testing.AsyncTestCase):
         yield tornado.gen.sleep(1.0)
 
         http = tornado.httpclient.AsyncHTTPClient()
-        response = yield http.fetch('http://127.0.0.1:%d/varz' % self.server_pool[0].http_port)
+        response = yield http.fetch(
+            'http://127.0.0.1:%d/varz' % self.server_pool[0].http_port)
         varz = json.loads(response.body)
         self.assertEqual(10, varz['in_bytes'])
         self.assertEqual(10, varz['out_bytes'])
@@ -618,17 +616,18 @@ class ClientTest(tornado.testing.AsyncTestCase):
             self.assertEqual(sub.msgs[i].subject, u"help.%s" % (i))
 
         http = tornado.httpclient.AsyncHTTPClient()
-        response = yield http.fetch('http://127.0.0.1:%d/varz' % self.server_pool[0].http_port)
+        response = yield http.fetch(
+            'http://127.0.0.1:%d/varz' % self.server_pool[0].http_port)
         varz = json.loads(response.body)
 
         self.assertEqual(500000001, varz['in_bytes'])
         self.assertEqual(500000001, varz['out_bytes'])
-        self.assertEqual(501,  varz['in_msgs'])
-        self.assertEqual(501,  varz['out_msgs'])
-        self.assertEqual(500000001,  nc.stats['in_bytes'])
-        self.assertEqual(500000001,  nc.stats['out_bytes'])
-        self.assertEqual(501,  nc.stats['in_msgs'])
-        self.assertEqual(501,  nc.stats['out_msgs'])
+        self.assertEqual(501, varz['in_msgs'])
+        self.assertEqual(501, varz['out_msgs'])
+        self.assertEqual(500000001, nc.stats['in_bytes'])
+        self.assertEqual(500000001, nc.stats['out_bytes'])
+        self.assertEqual(501, nc.stats['in_msgs'])
+        self.assertEqual(501, nc.stats['out_msgs'])
 
     @tornado.testing.gen_test(timeout=15)
     def test_publish_flush_race_condition(self):
@@ -681,24 +680,23 @@ class ClientTest(tornado.testing.AsyncTestCase):
             self.assertEqual(sub.msgs[i].subject, u"help.%s" % (i))
 
         http = tornado.httpclient.AsyncHTTPClient()
-        response = yield http.fetch('http://127.0.0.1:%d/varz' % self.server_pool[0].http_port)
+        response = yield http.fetch(
+            'http://127.0.0.1:%d/varz' % self.server_pool[0].http_port)
         varz = json.loads(response.body)
 
         self.assertEqual(500000001, varz['in_bytes'])
         self.assertEqual(500000001, varz['out_bytes'])
-        self.assertEqual(501,  varz['in_msgs'])
-        self.assertEqual(501,  varz['out_msgs'])
-        self.assertEqual(500000001,  nc.stats['in_bytes'])
-        self.assertEqual(500000001,  nc.stats['out_bytes'])
-        self.assertEqual(501,  nc.stats['in_msgs'])
-        self.assertEqual(501,  nc.stats['out_msgs'])
+        self.assertEqual(501, varz['in_msgs'])
+        self.assertEqual(501, varz['out_msgs'])
+        self.assertEqual(500000001, nc.stats['in_bytes'])
+        self.assertEqual(500000001, nc.stats['out_bytes'])
+        self.assertEqual(501, nc.stats['in_msgs'])
+        self.assertEqual(501, nc.stats['out_msgs'])
 
     @tornado.testing.gen_test
     def test_unsubscribe(self):
         nc = Client()
-        options = {
-            "io_loop": self.io_loop
-        }
+        options = {"io_loop": self.io_loop}
         yield nc.connect(**options)
 
         log = Log()
@@ -720,7 +718,8 @@ class ClientTest(tornado.testing.AsyncTestCase):
             nc._subs[sid].received
 
         http = tornado.httpclient.AsyncHTTPClient()
-        response = yield http.fetch('http://127.0.0.1:%d/connz' % self.server_pool[0].http_port)
+        response = yield http.fetch(
+            'http://127.0.0.1:%d/connz' % self.server_pool[0].http_port)
         result = json.loads(response.body)
         connz = result['connections'][0]
         self.assertEqual(0, connz['subscriptions'])
@@ -728,9 +727,7 @@ class ClientTest(tornado.testing.AsyncTestCase):
     @tornado.testing.gen_test
     def test_unsubscribe_only_if_max_reached(self):
         nc = Client()
-        options = {
-            "io_loop": self.io_loop
-        }
+        options = {"io_loop": self.io_loop}
         yield nc.connect(**options)
 
         log = Log()
@@ -755,7 +752,8 @@ class ClientTest(tornado.testing.AsyncTestCase):
             nc._subs[sid].received
 
         http = tornado.httpclient.AsyncHTTPClient()
-        response = yield http.fetch('http://127.0.0.1:%d/connz' % self.server_pool[0].http_port)
+        response = yield http.fetch(
+            'http://127.0.0.1:%d/connz' % self.server_pool[0].http_port)
         result = json.loads(response.body)
         connz = result['connections'][0]
         self.assertEqual(0, connz['subscriptions'])
@@ -788,7 +786,8 @@ class ClientTest(tornado.testing.AsyncTestCase):
         yield tornado.gen.sleep(0.5)
 
         http = tornado.httpclient.AsyncHTTPClient()
-        response = yield http.fetch('http://127.0.0.1:%d/varz' % self.server_pool[0].http_port)
+        response = yield http.fetch(
+            'http://127.0.0.1:%d/varz' % self.server_pool[0].http_port)
         varz = json.loads(response.body)
         self.assertEqual(18, varz['in_bytes'])
         self.assertEqual(32, varz['out_bytes'])
@@ -834,7 +833,8 @@ class ClientTest(tornado.testing.AsyncTestCase):
         self.assertEqual("ok:1", reply.data)
 
         http = tornado.httpclient.AsyncHTTPClient()
-        response = yield http.fetch('http://127.0.0.1:%d/varz' % self.server_pool[0].http_port)
+        response = yield http.fetch(
+            'http://127.0.0.1:%d/varz' % self.server_pool[0].http_port)
         varz = json.loads(response.body)
         self.assertEqual(18, varz['in_bytes'])
         self.assertEqual(28, varz['out_bytes'])
@@ -864,7 +864,8 @@ class ClientTest(tornado.testing.AsyncTestCase):
         self.assertTrue(len(info_keys) > 0)
 
         with self.assertRaises(ErrMaxPayload):
-            yield nc.publish("large-message", "A" * (nc._server_info["max_payload"] * 2))
+            yield nc.publish("large-message",
+                             "A" * (nc._server_info["max_payload"] * 2))
 
     @tornado.testing.gen_test
     def test_publish_request(self):
@@ -881,17 +882,18 @@ class ClientTest(tornado.testing.AsyncTestCase):
         yield tornado.gen.sleep(1.0)
 
         http = tornado.httpclient.AsyncHTTPClient()
-        response = yield http.fetch('http://127.0.0.1:%d/varz' % self.server_pool[0].http_port)
+        response = yield http.fetch(
+            'http://127.0.0.1:%d/varz' % self.server_pool[0].http_port)
         varz = json.loads(response.body)
 
         self.assertEqual(10, varz['in_bytes'])
-        self.assertEqual(0,  varz['out_bytes'])
-        self.assertEqual(2,  varz['in_msgs'])
-        self.assertEqual(0,  varz['out_msgs'])
-        self.assertEqual(0,  nc.stats['in_bytes'])
+        self.assertEqual(0, varz['out_bytes'])
+        self.assertEqual(2, varz['in_msgs'])
+        self.assertEqual(0, varz['out_msgs'])
+        self.assertEqual(0, nc.stats['in_bytes'])
         self.assertEqual(10, nc.stats['out_bytes'])
-        self.assertEqual(0,  nc.stats['in_msgs'])
-        self.assertEqual(2,  nc.stats['out_msgs'])
+        self.assertEqual(0, nc.stats['in_msgs'])
+        self.assertEqual(2, nc.stats['out_msgs'])
 
     @tornado.testing.gen_test
     def test_customize_io_buffers(self):
@@ -930,9 +932,7 @@ class ClientTest(tornado.testing.AsyncTestCase):
 
     @tornado.testing.gen_test
     def test_default_ping_interval(self):
-
         class Parser():
-
             def __init__(self, nc, t):
                 self.nc = nc
                 self.t = t
@@ -988,9 +988,8 @@ class ClientTest(tornado.testing.AsyncTestCase):
 
         nc = Client()
         nc._ps = Parser(nc)
-        yield nc.connect(io_loop=self.io_loop,
-                         ping_interval=0.1,
-                         max_outstanding_pings=20)
+        yield nc.connect(
+            io_loop=self.io_loop, ping_interval=0.1, max_outstanding_pings=20)
         yield tornado.gen.sleep(1)
 
         # Should have received more than 5 pongs, but processed none.
@@ -1009,7 +1008,6 @@ class ClientTest(tornado.testing.AsyncTestCase):
 
     @tornado.testing.gen_test
     def test_flush_timeout(self):
-
         class Parser():
             def __init__(self, nc, t):
                 self.nc = nc
@@ -1031,7 +1029,6 @@ class ClientTest(tornado.testing.AsyncTestCase):
 
     @tornado.testing.gen_test
     def test_flush_timeout_lost_message(self):
-
         class Parser():
             def __init__(self, nc):
                 self.nc = nc
@@ -1060,7 +1057,6 @@ class ClientTest(tornado.testing.AsyncTestCase):
 
     @tornado.testing.gen_test
     def test_timed_request_timeout(self):
-
         class Parser():
             def __init__(self, nc, t):
                 self.nc = nc
@@ -1082,17 +1078,16 @@ class ClientTest(tornado.testing.AsyncTestCase):
 
 
 class ClientAuthTest(tornado.testing.AsyncTestCase):
-
     def setUp(self):
-        print("\n=== RUN {0}.{1}".format(
-            self.__class__.__name__, self._testMethodName))
+        print("\n=== RUN {0}.{1}".format(self.__class__.__name__,
+                                         self._testMethodName))
         self.threads = []
         self.server_pool = []
 
         server1 = Gnatsd(port=4223, user="foo", password="bar", http_port=8223)
         self.server_pool.append(server1)
-        server2 = Gnatsd(port=4224, user="hoge",
-                         password="fuga", http_port=8224)
+        server2 = Gnatsd(
+            port=4224, user="hoge", password="fuga", http_port=8224)
         self.server_pool.append(server2)
 
         for gnatsd in self.server_pool:
@@ -1125,20 +1120,22 @@ class ClientAuthTest(tornado.testing.AsyncTestCase):
     def test_auth_connect(self):
         nc = Client()
         options = {
-            "dont_randomize": True,
+            "dont_randomize":
+            True,
             "servers": [
                 "nats://foo:bar@127.0.0.1:4223",
                 "nats://hoge:fuga@127.0.0.1:4224"
             ],
-            "io_loop": self.io_loop
+            "io_loop":
+            self.io_loop
         }
         yield nc.connect(**options)
         self.assertEqual(True, nc._server_info["auth_required"])
 
         log = Log()
-        sid_1 = yield nc.subscribe("foo",  "", log.persist)
+        sid_1 = yield nc.subscribe("foo", "", log.persist)
         self.assertEqual(sid_1, 1)
-        sid_2 = yield nc.subscribe("bar",  "", log.persist)
+        sid_2 = yield nc.subscribe("bar", "", log.persist)
         self.assertEqual(sid_2, 2)
         sid_3 = yield nc.subscribe("quux", "", log.persist)
         self.assertEqual(sid_3, 3)
@@ -1201,7 +1198,6 @@ class ClientAuthTest(tornado.testing.AsyncTestCase):
 
     @tornado.testing.gen_test(timeout=10)
     def test_auth_connect_fails(self):
-
         class Component:
             def __init__(self, nc):
                 self.nc = nc
@@ -1229,27 +1225,35 @@ class ClientAuthTest(tornado.testing.AsyncTestCase):
         nc = Client()
         component = Component(nc)
         options = {
-            "dont_randomize": True,
+            "dont_randomize":
+            True,
             "servers": [
                 "nats://foo:bar@127.0.0.1:4223",
                 "nats://foo2:bar2@127.0.0.1:4224"
             ],
-            "io_loop": self.io_loop,
-            "close_cb": component.close_cb,
-            "error_cb": component.error_cb,
-            "disconnected_cb": component.disconnected_cb,
-            "reconnected_cb": component.reconnected_cb,
-            "max_reconnect_attempts": 5,
-            "reconnect_time_wait": 0.1
+            "io_loop":
+            self.io_loop,
+            "close_cb":
+            component.close_cb,
+            "error_cb":
+            component.error_cb,
+            "disconnected_cb":
+            component.disconnected_cb,
+            "reconnected_cb":
+            component.reconnected_cb,
+            "max_reconnect_attempts":
+            5,
+            "reconnect_time_wait":
+            0.1
         }
         yield component.nc.connect(**options)
         self.assertEqual(True, component.nc.is_connected)
         self.assertEqual(True, nc._server_info["auth_required"])
 
         log = Log()
-        sid_1 = yield component.nc.subscribe("foo",  "", log.persist)
+        sid_1 = yield component.nc.subscribe("foo", "", log.persist)
         self.assertEqual(sid_1, 1)
-        sid_2 = yield component.nc.subscribe("bar",  "", log.persist)
+        sid_2 = yield component.nc.subscribe("bar", "", log.persist)
         self.assertEqual(sid_2, 2)
         sid_3 = yield component.nc.subscribe("quux", "", log.persist)
         self.assertEqual(sid_3, 3)
@@ -1300,11 +1304,10 @@ class ClientAuthTest(tornado.testing.AsyncTestCase):
     # @tornado.testing.gen_test(timeout=15)
     @unittest.skip("FIXME: flapping test")
     def test_auth_pending_bytes_handling(self):
-        
+
         nc = Client()
 
         class Component:
-
             def __init__(self, nc):
                 self.nc = nc
                 self.errors = []
@@ -1334,22 +1337,28 @@ class ClientAuthTest(tornado.testing.AsyncTestCase):
 
         c = Component(nc)
         options = {
-            "dont_randomize": True,
+            "dont_randomize":
+            True,
             "servers": [
                 "nats://foo:bar@127.0.0.1:4223",
                 "nats://hoge:fuga@127.0.0.1:4224"
             ],
-            "io_loop": self.io_loop,
-            "reconnected_cb": c.reconnected_cb,
-            "disconnected_cb": c.disconnected_cb,
-            "error_cb": c.error_cb,
-            "reconnect_time_wait": 0.1
+            "io_loop":
+            self.io_loop,
+            "reconnected_cb":
+            c.reconnected_cb,
+            "disconnected_cb":
+            c.disconnected_cb,
+            "error_cb":
+            c.error_cb,
+            "reconnect_time_wait":
+            0.1
         }
         yield c.nc.connect(**options)
         self.assertEqual(True, nc._server_info["auth_required"])
 
         log = Log()
-        yield c.nc.subscribe("foo",  "", log.persist)
+        yield c.nc.subscribe("foo", "", log.persist)
         self.io_loop.spawn_callback(c.publisher)
 
         a = nc._current_server
@@ -1375,8 +1384,8 @@ class ClientAuthTest(tornado.testing.AsyncTestCase):
         result = json.loads(response.body)
         connz = result['connections'][0]
         self.assertTrue(connz['in_msgs'] > 0)
-        self.assertTrue(c.pending_bytes_when_reconnected >
-                        c.pending_bytes_when_closed)
+        self.assertTrue(
+            c.pending_bytes_when_reconnected > c.pending_bytes_when_closed)
 
         # Give a small margin of error in case we didn't grab the
         # self.assertTrue(c.max_messages - c.disconnected_at - 5 < connz['in_msgs'] < c.max_messages - c.disconnected_at + 5)
@@ -1402,20 +1411,22 @@ class ClientAuthTest(tornado.testing.AsyncTestCase):
     def test_close_connection(self):
         nc = Client()
         options = {
-            "dont_randomize": True,
+            "dont_randomize":
+            True,
             "servers": [
                 "nats://foo:bar@127.0.0.1:4223",
                 "nats://hoge:fuga@127.0.0.1:4224"
             ],
-            "io_loop": self.io_loop
+            "io_loop":
+            self.io_loop
         }
         yield nc.connect(**options)
         self.assertEqual(True, nc._server_info["auth_required"])
 
         log = Log()
-        sid_1 = yield nc.subscribe("foo",  "", log.persist)
+        sid_1 = yield nc.subscribe("foo", "", log.persist)
         self.assertEqual(sid_1, 1)
-        sid_2 = yield nc.subscribe("bar",  "", log.persist)
+        sid_2 = yield nc.subscribe("bar", "", log.persist)
         self.assertEqual(sid_2, 2)
         sid_3 = yield nc.subscribe("quux", "", log.persist)
         self.assertEqual(sid_3, 3)
@@ -1440,30 +1451,29 @@ class ClientAuthTest(tornado.testing.AsyncTestCase):
         self.assertFalse(nc.is_reconnecting)
         self.assertTrue(nc.is_closed)
 
-        with(self.assertRaises(ErrConnectionClosed)):
+        with (self.assertRaises(ErrConnectionClosed)):
             yield nc.publish("hello", "world")
 
-        with(self.assertRaises(ErrConnectionClosed)):
+        with (self.assertRaises(ErrConnectionClosed)):
             yield nc.flush()
 
-        with(self.assertRaises(ErrConnectionClosed)):
+        with (self.assertRaises(ErrConnectionClosed)):
             yield nc.subscribe("hello", "worker")
 
-        with(self.assertRaises(ErrConnectionClosed)):
+        with (self.assertRaises(ErrConnectionClosed)):
             yield nc.publish_request("hello", "inbox", "world")
 
-        with(self.assertRaises(ErrConnectionClosed)):
+        with (self.assertRaises(ErrConnectionClosed)):
             yield nc.request("hello", "world")
 
-        with(self.assertRaises(ErrConnectionClosed)):
+        with (self.assertRaises(ErrConnectionClosed)):
             yield nc.timed_request("hello", "world")
 
 
 class ClientTLSTest(tornado.testing.AsyncTestCase):
-
     def setUp(self):
-        print("\n=== RUN {0}.{1}".format(
-            self.__class__.__name__, self._testMethodName))
+        print("\n=== RUN {0}.{1}".format(self.__class__.__name__,
+                                         self._testMethodName))
         self.threads = []
         self.server_pool = []
 
@@ -1513,7 +1523,6 @@ class ClientTLSTest(tornado.testing.AsyncTestCase):
 
     @tornado.testing.gen_test(timeout=10)
     def test_tls_connection(self):
-
         class Component:
             def __init__(self, nc):
                 self.nc = nc
@@ -1544,9 +1553,7 @@ class ClientTLSTest(tornado.testing.AsyncTestCase):
         nc = Client()
         c = Component(nc)
         options = {
-            "servers": [
-                "nats://127.0.0.1:4444"
-            ],
+            "servers": ["nats://127.0.0.1:4444"],
             "io_loop": self.io_loop,
             "close_cb": c.close_cb,
             "error_cb": c.error_cb,
@@ -1574,8 +1581,7 @@ class ClientTLSTest(tornado.testing.AsyncTestCase):
         self.assertFalse(c.reconnected_cb_called)
 
     @tornado.testing.gen_test(timeout=15)
-    def test_tls_reconnection(self):      
-
+    def test_tls_reconnection(self):
         class Component:
             def __init__(self, nc):
                 self.nc = nc
@@ -1634,7 +1640,8 @@ class ClientTLSTest(tornado.testing.AsyncTestCase):
         try:
             a = nc._current_server
             # Wait for reconnect logic kick in...
-            yield tornado.gen.with_timeout(timedelta(seconds=10), c.reconnected_future)
+            yield tornado.gen.with_timeout(
+                timedelta(seconds=10), c.reconnected_future)
         finally:
             b = nc._current_server
             self.assertNotEqual(a.uri, b.uri)
@@ -1658,10 +1665,9 @@ class ClientTLSTest(tornado.testing.AsyncTestCase):
 
 
 class ClientTLSCertsTest(tornado.testing.AsyncTestCase):
-
     def setUp(self):
-        print("\n=== RUN {0}.{1}".format(
-            self.__class__.__name__, self._testMethodName))
+        print("\n=== RUN {0}.{1}".format(self.__class__.__name__,
+                                         self._testMethodName))
         super(ClientTLSCertsTest, self).setUp()
 
     class Component:
@@ -1696,9 +1702,7 @@ class ClientTLSCertsTest(tornado.testing.AsyncTestCase):
         nc = Client()
         c = self.Component(nc)
         options = {
-            "servers": [
-                "nats://127.0.0.1:4446"
-            ],
+            "servers": ["nats://127.0.0.1:4446"],
             "allow_reconnect": False,
             "io_loop": self.io_loop,
             "close_cb": c.close_cb,
@@ -1708,7 +1712,7 @@ class ClientTLSCertsTest(tornado.testing.AsyncTestCase):
             "tls": {
                 "cert_reqs": ssl.CERT_REQUIRED,
                 "ca_certs": "./tests/configs/certs/ca.pem",
-                "keyfile":  "./tests/configs/certs/client-key.pem",
+                "keyfile": "./tests/configs/certs/client-key.pem",
                 "certfile": "./tests/configs/certs/client-cert.pem"
             }
         }
@@ -1752,9 +1756,7 @@ class ClientTLSCertsTest(tornado.testing.AsyncTestCase):
         nc = Client()
         c = self.Component(nc)
         options = {
-            "servers": [
-                "nats://127.0.0.1:4446"
-            ],
+            "servers": ["nats://127.0.0.1:4446"],
             "allow_reconnect": False,
             "io_loop": self.io_loop,
             "close_cb": c.close_cb,
@@ -1764,7 +1766,7 @@ class ClientTLSCertsTest(tornado.testing.AsyncTestCase):
             "tls": {
                 "cert_reqs": ssl.CERT_REQUIRED,
                 "ca_certs": "./tests/configs/certs/ca.pem",
-                "keyfile":  "./tests/configs/certs/client-key.pem",
+                "keyfile": "./tests/configs/certs/client-key.pem",
                 "certfile": "./tests/configs/certs/client-cert.pem"
             }
         }
@@ -1795,9 +1797,7 @@ class ClientTLSCertsTest(tornado.testing.AsyncTestCase):
         port = 4447
         http_port = 8447
         options = {
-            "servers": [
-                "nats://127.0.0.1:%d" % port
-            ],
+            "servers": ["nats://127.0.0.1:%d" % port],
             "max_reconnect_attempts": 5,
             "io_loop": self.io_loop,
             "close_cb": c.close_cb,
@@ -1808,7 +1808,7 @@ class ClientTLSCertsTest(tornado.testing.AsyncTestCase):
             "tls": {
                 "cert_reqs": ssl.CERT_REQUIRED,
                 # "ca_certs": "./tests/configs/certs/ca.pem",
-                "keyfile":  "./tests/configs/certs/client-key.pem",
+                "keyfile": "./tests/configs/certs/client-key.pem",
                 "certfile": "./tests/configs/certs/client-cert.pem"
             }
         }
@@ -1864,10 +1864,9 @@ class LargeControlLineNATSServer(tornado.tcpserver.TCPServer):
 
 
 class ClientConnectTest(tornado.testing.AsyncTestCase):
-
     def setUp(self):
-        print("\n=== RUN {0}.{1}".format(
-            self.__class__.__name__, self._testMethodName))
+        print("\n=== RUN {0}.{1}".format(self.__class__.__name__,
+                                         self._testMethodName))
         super(ClientConnectTest, self).setUp()
 
     def tearDown(self):
@@ -1881,9 +1880,7 @@ class ClientConnectTest(tornado.testing.AsyncTestCase):
         nc = Client()
         options = {
             "dont_randomize": True,
-            "servers": [
-                "nats://127.0.0.1:4229"
-            ],
+            "servers": ["nats://127.0.0.1:4229"],
             "io_loop": self.io_loop,
             "verbose": False
         }
@@ -1898,20 +1895,18 @@ class ClientConnectTest(tornado.testing.AsyncTestCase):
         nc = Client()
         options = {
             "dont_randomize": True,
-            "servers": [
-                "nats://127.0.0.1:4229"
-            ],
+            "servers": ["nats://127.0.0.1:4229"],
             "io_loop": self.io_loop,
             "verbose": False
         }
         yield nc.connect(**options)
         self.assertTrue(nc.is_connected)
 
-class ClientClusteringDiscoveryTest(tornado.testing.AsyncTestCase):
 
+class ClientClusteringDiscoveryTest(tornado.testing.AsyncTestCase):
     def setUp(self):
-        print("\n=== RUN {0}.{1}".format(
-            self.__class__.__name__, self._testMethodName))
+        print("\n=== RUN {0}.{1}".format(self.__class__.__name__,
+                                         self._testMethodName))
         super(ClientClusteringDiscoveryTest, self).setUp()
 
     def tearDown(self):
@@ -1929,24 +1924,28 @@ class ClientClusteringDiscoveryTest(tornado.testing.AsyncTestCase):
 
         nc = Client()
         options = {
-            "servers": [
-                "nats://127.0.0.1:4222"
-            ],
+            "servers": ["nats://127.0.0.1:4222"],
             "io_loop": self.io_loop,
         }
 
-        with Gnatsd(port=4222, http_port=8222, cluster_port=6222, conf=conf) as nats1:
+        with Gnatsd(
+                port=4222, http_port=8222, cluster_port=6222,
+                conf=conf) as nats1:
             yield nc.connect(**options)
             yield tornado.gen.sleep(1)
             initial_uri = nc.connected_url
-            with Gnatsd(port=4223, http_port=8223, cluster_port=6223, conf=conf) as nats2:
+            with Gnatsd(
+                    port=4223, http_port=8223, cluster_port=6223,
+                    conf=conf) as nats2:
                 yield tornado.gen.sleep(1)
                 srvs = {}
                 for item in nc._server_pool:
                     srvs[item.uri.port] = True
                 self.assertEqual(len(srvs.keys()), 2)
 
-                with Gnatsd(port=4224, http_port=8224, cluster_port=6224, conf=conf) as nats3:
+                with Gnatsd(
+                        port=4224, http_port=8224, cluster_port=6224,
+                        conf=conf) as nats3:
                     yield tornado.gen.sleep(1)
                     for item in nc._server_pool:
                         srvs[item.uri.port] = True
@@ -1981,17 +1980,19 @@ class ClientClusteringDiscoveryTest(tornado.testing.AsyncTestCase):
 
         nc = Client()
         options = {
-            "servers": [
-                "nats://127.0.0.1:4222"
-            ],
+            "servers": ["nats://127.0.0.1:4222"],
             "dont_randomize": True,
             "io_loop": self.io_loop,
         }
 
-        with Gnatsd(port=4222, http_port=8222, cluster_port=6222, conf=conf) as nats1:
+        with Gnatsd(
+                port=4222, http_port=8222, cluster_port=6222,
+                conf=conf) as nats1:
             yield nc.connect(**options)
             yield tornado.gen.sleep(0.5)
-            with Gnatsd(port=4223, http_port=8223, cluster_port=6223, conf=conf) as nats2:
+            with Gnatsd(
+                    port=4223, http_port=8223, cluster_port=6223,
+                    conf=conf) as nats2:
                 yield tornado.gen.sleep(1)
                 srvs = []
                 for item in nc._server_pool:
@@ -1999,13 +2000,16 @@ class ClientClusteringDiscoveryTest(tornado.testing.AsyncTestCase):
                         srvs.append(item.uri.port)
                 self.assertEqual(len(srvs), 2)
 
-                with Gnatsd(port=4224, http_port=8224, cluster_port=6224, conf=conf) as nats3:
+                with Gnatsd(
+                        port=4224, http_port=8224, cluster_port=6224,
+                        conf=conf) as nats3:
                     yield tornado.gen.sleep(1)
                     for item in nc._server_pool:
                         if item.uri.port not in srvs:
                             srvs.append(item.uri.port)
                     self.assertEqual([4222, 4223, 4224], srvs)
         yield nc.close()
+
 
 if __name__ == '__main__':
     runner = unittest.TextTestRunner(stream=sys.stdout)

--- a/tests/nuid_test.py
+++ b/tests/nuid_test.py
@@ -17,11 +17,11 @@ import unittest
 from nats.io.nuid import NUID, MAX_SEQ, PREFIX_LENGTH, TOTAL_LENGTH
 from collections import Counter
 
-class NUIDTest(unittest.TestCase):
 
+class NUIDTest(unittest.TestCase):
     def setUp(self):
-        print("\n=== RUN {0}.{1}".format(
-            self.__class__.__name__, self._testMethodName))
+        print("\n=== RUN {0}.{1}".format(self.__class__.__name__,
+                                         self._testMethodName))
         super(NUIDTest, self).setUp()
 
     def test_nuid_length(self):
@@ -32,14 +32,18 @@ class NUIDTest(unittest.TestCase):
         nuid = NUID()
         entries = [nuid.next().decode() for i in range(500000)]
         counted_entries = Counter(entries)
-        repeated = [entry for entry, count in counted_entries.items() if count > 1]
+        repeated = [
+            entry for entry, count in counted_entries.items() if count > 1
+        ]
         self.assertEqual(len(repeated), 0)
 
     def test_nuid_are_very_unique(self):
         nuid = NUID()
         entries = [nuid.next().decode() for i in range(1000000)]
         counted_entries = Counter(entries)
-        repeated = [entry for entry, count in counted_entries.items() if count > 1]
+        repeated = [
+            entry for entry, count in counted_entries.items() if count > 1
+        ]
         self.assertEqual(len(repeated), 0)
 
     def test_nuid_sequence_rollover(self):
@@ -56,9 +60,10 @@ class NUIDTest(unittest.TestCase):
         self.assertEqual(nuid_a[:PREFIX_LENGTH], nuid_b[:PREFIX_LENGTH])
 
         # Force the sequence to rollover, prefix should now change
-        nuid._seq = seq_c = MAX_SEQ+1
+        nuid._seq = seq_c = MAX_SEQ + 1
         nuid_c = nuid.next()
         self.assertNotEqual(nuid_a[:PREFIX_LENGTH], nuid_c[:PREFIX_LENGTH])
+
 
 if __name__ == '__main__':
     runner = unittest.TextTestRunner(stream=sys.stdout)

--- a/tests/protocol_test.py
+++ b/tests/protocol_test.py
@@ -8,7 +8,6 @@ from nats.protocol.parser import *
 
 
 class MockNatsClient:
-
     def __init__(self):
         self._subs = {}
         self._pongs = []
@@ -42,7 +41,6 @@ class MockNatsClient:
 
 
 class ProtocolParserTest(tornado.testing.AsyncTestCase):
-
     @tornado.testing.gen_test
     def test_parse_ping(self):
         ps = Parser(MockNatsClient())


### PR DESCRIPTION
Reformat code using [google's yapf](https://github.com/google/yapf) python formatter. There were some inconsistencies that this tool should fix. Next I would like to plug this into the travis build to either auto-format code on PRs or fail the build if the format isn't correct. This PR should be purely cosmetic and not affect functionality.

