### PR TITLE
Request/Response rework

### DIFF
--- a/benchmark/latency_perf.py
+++ b/benchmark/latency_perf.py
@@ -31,53 +31,50 @@ received = 0
 
 @tornado.gen.coroutine
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        '-n', '--iterations', default=DEFAULT_ITERATIONS, type=int)
-    parser.add_argument('-S', '--subject', default='test')
-    parser.add_argument('--servers', default=[], action='append')
-    args = parser.parse_args()
+  parser = argparse.ArgumentParser()
+  parser.add_argument('-n', '--iterations', default=DEFAULT_ITERATIONS, type=int)
+  parser.add_argument('-S', '--subject', default='test')
+  parser.add_argument('--servers', default=[], action='append')
+  args = parser.parse_args()
 
-    servers = args.servers
-    if len(args.servers) < 1:
-        servers = ["nats://127.0.0.1:4222"]
-    opts = {"servers": servers}
+  servers = args.servers
+  if len(args.servers) < 1:
+    servers = ["nats://127.0.0.1:4222"]
+  opts = { "servers": servers }
 
-    # Make sure we're connected to a server first...
-    nc = NATS()
-    try:
-        yield nc.connect(**opts)
-    except Exception, e:
-        sys.stderr.write("ERROR: {0}".format(e))
-        show_usage_and_die()
+  # Make sure we're connected to a server first...
+  nc = NATS()
+  try:
+    yield nc.connect(**opts)
+  except Exception, e:
+    sys.stderr.write("ERROR: {0}".format(e))
+    show_usage_and_die()
 
-    @tornado.gen.coroutine
-    def handler(msg):
-        yield nc.publish(msg.reply, "")
+  @tornado.gen.coroutine
+  def handler(msg):
+    yield nc.publish(msg.reply, "")
+  yield nc.subscribe(args.subject, cb=handler)
 
-    yield nc.subscribe(args.subject, cb=handler)
+  # Start the benchmark
+  start = time.time()
+  to_send = args.iterations
 
-    # Start the benchmark
-    start = time.time()
-    to_send = args.iterations
+  print("Sending {0} request/responses on [{1}]".format(
+      args.iterations, args.subject))
+  while to_send > 0:
+    to_send -= 1
+    if to_send == 0:
+      break
 
-    print("Sending {0} request/responses on [{1}]".format(
-        args.iterations, args.subject))
-    while to_send > 0:
-        to_send -= 1
-        if to_send == 0:
-            break
+    yield nc.request(args.subject, "")
+    if (to_send % HASH_MODULO) == 0:
+      sys.stdout.write("+")
+      sys.stdout.flush()
 
-        yield nc.timed_request(args.subject, "")
-        if (to_send % HASH_MODULO) == 0:
-            sys.stdout.write("+")
-            sys.stdout.flush()
-
-    duration = time.time() - start
-    ms = "%.3f" % ((duration / args.iterations) * 1000)
-    print("\nTest completed : {0} ms avg request/response latency".format(ms))
-    yield nc.close()
-
+  duration = time.time() - start
+  ms = "%.3f" % ((duration/args.iterations) * 1000)
+  print("\nTest completed : {0} ms avg request/response latency".format(ms))
+  yield nc.close()
 
 if __name__ == '__main__':
     tornado.ioloop.IOLoop.instance().run_sync(main)

--- a/nats/io/client.py
+++ b/nats/io/client.py
@@ -68,7 +68,7 @@ DEFAULT_PENDING_SIZE = 1024 * 1024
 DEFAULT_MAX_PAYLOAD_SIZE = 1048576
 
 # Default Pending Limits of Subscriptions
-DEFAULT_SUB_PENDING_MSGS_LIMIT  = 65536
+DEFAULT_SUB_PENDING_MSGS_LIMIT = 65536
 DEFAULT_SUB_PENDING_BYTES_LIMIT = 65536 * 1024
 
 PROTOCOL = 1
@@ -452,11 +452,12 @@ class Client(object):
             next_inbox = INBOX_PREFIX[:]
             next_inbox.extend(self._nuid.next())
             inbox = str(next_inbox)
-            sid = yield self.subscribe(inbox,
-                                       queue=_EMPTY_,
-                                       cb=cb,
-                                       max_msgs=expected,
-                                       )
+            sid = yield self.subscribe(
+                inbox,
+                queue=_EMPTY_,
+                cb=cb,
+                max_msgs=expected,
+            )
             yield self.auto_unsubscribe(sid, expected)
             yield self.publish_request(subject, inbox, payload)
             raise tornado.gen.Return(sid)
@@ -476,8 +477,7 @@ class Client(object):
             sub.pending_msgs_limit = DEFAULT_SUB_PENDING_MSGS_LIMIT
             sub.pending_bytes_limit = DEFAULT_SUB_PENDING_BYTES_LIMIT
             sub.pending_queue = tornado.queues.Queue(
-                maxsize=sub.pending_msgs_limit,
-                )
+                maxsize=sub.pending_msgs_limit)
 
             # Single task for handling the requests
             @tornado.gen.coroutine
@@ -512,8 +512,10 @@ class Client(object):
             self._subs[sid] = sub
 
             # Send SUB command...
-            sub_cmd = b''.join([SUB_OP, _SPC_, sub.subject.encode(
-                ), _SPC_, ("%d" % sid).encode(), _CRLF_])
+            sub_cmd = b''.join([
+                SUB_OP, _SPC_,
+                sub.subject.encode(), _SPC_, ("%d" % sid).encode(), _CRLF_
+            ])
             yield self.send_command(sub_cmd)
             yield self._flush_pending()
 
@@ -524,7 +526,8 @@ class Client(object):
         future = tornado.concurrent.Future()
         self._resp_map[token.decode()] = future
         yield self.publish_request(subject, str(inbox), payload)
-        msg = yield tornado.gen.with_timeout(timedelta(seconds=timeout), future)
+        msg = yield tornado.gen.with_timeout(
+            timedelta(seconds=timeout), future)
         raise tornado.gen.Return(msg)
 
     @tornado.gen.coroutine
@@ -555,16 +558,17 @@ class Client(object):
         raise tornado.gen.Return(msg)
 
     @tornado.gen.coroutine
-    def subscribe(self,
-                  subject="",
-                  queue="",
-                  cb=None,
-                  future=None,
-                  max_msgs=0,
-                  is_async=False,
-                  pending_msgs_limit=DEFAULT_SUB_PENDING_MSGS_LIMIT,
-                  pending_bytes_limit=DEFAULT_SUB_PENDING_BYTES_LIMIT,
-                  ):
+    def subscribe(
+            self,
+            subject="",
+            queue="",
+            cb=None,
+            future=None,
+            max_msgs=0,
+            is_async=False,
+            pending_msgs_limit=DEFAULT_SUB_PENDING_MSGS_LIMIT,
+            pending_bytes_limit=DEFAULT_SUB_PENDING_BYTES_LIMIT,
+    ):
         """
         Sends a SUB command to the server. Takes a queue parameter
         which can be used in case of distributed queues or left empty
@@ -591,8 +595,7 @@ class Client(object):
             sub.pending_msgs_limit = pending_msgs_limit
             sub.pending_bytes_limit = pending_bytes_limit
             sub.pending_queue = tornado.queues.Queue(
-                maxsize=pending_msgs_limit,
-                )
+                maxsize=pending_msgs_limit)
 
             @tornado.gen.coroutine
             def wait_for_msgs():
@@ -604,7 +607,7 @@ class Client(object):
                         sub = wait_for_msgs.sub
                         if sub.closed:
                             break
-                        
+
                         msg = yield sub.pending_queue.get()
                         if msg is None:
                             break
@@ -646,8 +649,11 @@ class Client(object):
             sub.future = future
 
         # Send SUB command...
-        sub_cmd = b''.join([SUB_OP, _SPC_, sub.subject.encode(
-        ), _SPC_, sub.queue.encode(), _SPC_, ("%d" % sid).encode(), _CRLF_])
+        sub_cmd = b''.join([
+            SUB_OP, _SPC_,
+            sub.subject.encode(), _SPC_,
+            sub.queue.encode(), _SPC_, ("%d" % sid).encode(), _CRLF_
+        ])
         yield self.send_command(sub_cmd)
         yield self._flush_pending()
         raise tornado.gen.Return(sid)
@@ -1080,7 +1086,7 @@ class Client(object):
             self.io.close()
 
         # Cleanup subscriptions since not reconnecting so no need
-        # to replay the subscriptions anymore.        
+        # to replay the subscriptions anymore.
         for ssid, sub in self._subs.items():
             self._subs.pop(ssid, None)
             self._remove_subscription(sub)
@@ -1233,15 +1239,17 @@ class Subscription():
         self.pending_size = 0
         self.closed = False
 
+
 class Msg(object):
     __slots__ = 'subject', 'reply', 'data', 'sid'
 
-    def __init__(self,
-                 subject='',
-                 reply='',
-                 data=b'',
-                 sid=0,
-        ):
+    def __init__(
+            self,
+            subject='',
+            reply='',
+            data=b'',
+            sid=0,
+    ):
         self.subject = subject
         self.reply = reply
         self.data = data
@@ -1253,7 +1261,8 @@ class Msg(object):
             self.subject,
             self.reply,
             self.data[:10].decode(),
-            )
+        )
+
 
 class Srv(object):
     """

--- a/nats/io/client.py
+++ b/nats/io/client.py
@@ -421,9 +421,24 @@ class Client(object):
     @tornado.gen.coroutine
     def request(self, subject, payload, timeout=0.5, expected=1, cb=None):
         """
-        Implements the request/response pattern via pub/sub
-        using an ephemeral subscription which will be published
-        with customizable limited interest.
+        Implements the request/response pattern via pub/sub using an
+        unique reply subject and an async subscription.
+
+        If cb is None, then it will wait and return a single message
+        using the new request/response style that is less chatty over
+        the network.
+
+          ->> SUB _INBOX.BF6zPVxvScfXGd4VyUMJyo.* 1
+          ->> PUB hello _INBOX.BF6zPVxvScfXGd4VyUMJyo.BF6zPVxvScfXCh4VyUMJyo 5
+          ->> MSG_PAYLOAD: hello
+          <<- MSG hello 2 _INBOX.BF6zPVxvScfXGd4VyUMJyo.BF6zPVxvScfXCh4VyUMJyo 5
+          ->> PUB _INBOX.BF6zPVxvScfXGd4VyUMJyo.BF6zPVxvScfXCh4VyUMJyo  5
+          ->> MSG_PAYLOAD: world
+          <<- MSG _INBOX.BF6zPVxvScfXGd4VyUMJyo.BF6zPVxvScfXCh4VyUMJyo 1 5
+
+        If a cb is passed, then it will use auto unsubscribe
+        functionality and expect a limited number of messages which
+        will be handled asynchronously in the callback.
 
           ->> SUB _INBOX.gnKUg9bmAHANjxIsDiQsWO 90
           ->> UNSUB 90 1

--- a/nats/io/client.py
+++ b/nats/io/client.py
@@ -1039,13 +1039,14 @@ class Subscription():
 
 
 class Msg(object):
-    def __init__(
-            self,
-            subject='',
-            reply='',
-            data=b'',
-            sid=0,
-    ):
+    __slots__ = 'subject', 'reply', 'data', 'sid'
+
+    def __init__(self,
+                 subject='',
+                 reply='',
+                 data=b'',
+                 sid=0,
+        ):
         self.subject = subject
         self.reply = reply
         self.data = data

--- a/nats/io/client.py
+++ b/nats/io/client.py
@@ -1052,6 +1052,13 @@ class Msg(object):
         self.data = data
         self.sid = sid
 
+    def __repr__(self):
+        return "<{}: subject='{}' reply='{}' data='{}...'>".format(
+            self.__class__.__name__,
+            self.subject,
+            self.reply,
+            self.data[:10].decode(),
+            )
 
 class Srv(object):
     """

--- a/nats/io/client.py
+++ b/nats/io/client.py
@@ -452,7 +452,11 @@ class Client(object):
             next_inbox = INBOX_PREFIX[:]
             next_inbox.extend(self._nuid.next())
             inbox = str(next_inbox)
-            sid = yield self.subscribe(inbox, _EMPTY_, cb)
+            sid = yield self.subscribe(inbox,
+                                       queue=_EMPTY_,
+                                       cb=cb,
+                                       max_msgs=expected,
+                                       )
             yield self.auto_unsubscribe(sid, expected)
             yield self.publish_request(subject, inbox, payload)
             raise tornado.gen.Return(sid)

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -742,7 +742,7 @@ class ClientTest(tornado.testing.AsyncTestCase):
         yield tornado.gen.sleep(1)
         self.assertEqual(3, len(log.records["foo"]))
 
-        sub = nc._subs[sid]        
+        sub = nc._subs[sid]
         yield nc.unsubscribe(sid, 3)
         self.assertEqual(sub.closed, True)
 
@@ -791,7 +791,7 @@ class ClientTest(tornado.testing.AsyncTestCase):
         yield nc.subscribe(">", "", log.persist)
         yield nc.subscribe("help", "", c.respond)
         yield nc.request("help", "please", expected=2, cb=c.receive_responses)
-        
+
         subs = []
         for _, sub in nc._subs.items():
             subs.append(sub)
@@ -1127,6 +1127,7 @@ class ClientTest(tornado.testing.AsyncTestCase):
         def sub_quux_handler(msg):
             msgs = sub_quux_handler.msgs
             msgs.append(msg)
+
         sub_quux_handler.msgs = []
         yield nc.subscribe("quux", cb=sub_quux_handler)
 
@@ -1150,10 +1151,10 @@ class ClientTest(tornado.testing.AsyncTestCase):
 
         def error_cb(err):
             error_cb.errors.append(err)
+
         error_cb.errors = []
 
-        yield nc.connect(io_loop=self.io_loop,
-                         error_cb=error_cb)
+        yield nc.connect(io_loop=self.io_loop, error_cb=error_cb)
 
         @tornado.gen.coroutine
         def sub_hello_handler(msg):
@@ -1202,10 +1203,10 @@ class ClientTest(tornado.testing.AsyncTestCase):
 
         def error_cb(err):
             error_cb.errors.append(err)
+
         error_cb.errors = []
 
-        yield nc.connect(io_loop=self.io_loop,
-                         error_cb=error_cb)
+        yield nc.connect(io_loop=self.io_loop, error_cb=error_cb)
 
         @tornado.gen.coroutine
         def sub_hello_handler(msg):
@@ -1217,7 +1218,8 @@ class ClientTest(tornado.testing.AsyncTestCase):
 
         sub_hello_handler.msgs = []
         sub_hello_handler.data = ''
-        yield nc.subscribe("hello", cb=sub_hello_handler, pending_bytes_limit=10)
+        yield nc.subscribe(
+            "hello", cb=sub_hello_handler, pending_bytes_limit=10)
 
         for i in range(0, 20):
             yield nc.publish("hello", "A")
@@ -1255,10 +1257,10 @@ class ClientTest(tornado.testing.AsyncTestCase):
 
         def error_cb(err):
             error_cb.errors.append(err)
+
         error_cb.errors = []
 
-        yield nc.connect(io_loop=self.io_loop,
-                         error_cb=error_cb)
+        yield nc.connect(io_loop=self.io_loop, error_cb=error_cb)
 
         @tornado.gen.coroutine
         def sub_hello_handler(msg):
@@ -1268,8 +1270,8 @@ class ClientTest(tornado.testing.AsyncTestCase):
         sub_hello_handler.msgs = []
         yield nc.subscribe("hello.foo.bar", cb=sub_hello_handler)
         yield nc.subscribe("hello.*.*", cb=sub_hello_handler)
-        yield nc.subscribe("hello.>", cb=sub_hello_handler)        
-        yield nc.subscribe(">", cb=sub_hello_handler)        
+        yield nc.subscribe("hello.>", cb=sub_hello_handler)
+        yield nc.subscribe(">", cb=sub_hello_handler)
 
         self.assertEqual(len(self.io_loop._callbacks), 5)
         for i in range(0, 10):
@@ -1296,6 +1298,7 @@ class ClientTest(tornado.testing.AsyncTestCase):
 
         for sub in subs:
             self.assertEqual(sub.closed, True)
+
 
 class ClientAuthTest(tornado.testing.AsyncTestCase):
     def setUp(self):


### PR DESCRIPTION
Rework of the message processing in order to update the handling of request/response closer to how the Go NATS client handles it (along with a few fixes).

- `request` now uses a single async wildcard subscription for handling the responses

- `request` method when not passed a callback now returns a future that can be awaited for the result which would be the message. When passed a callback it still works asynchronously.

- Each subscription now spawns a callback for processing the messages using a tornado queue to which the messages are buffered.  The pending queue can be customized with new `pending_msgs_limit` and `pending_bytes_limit` options on `subscribe`. (defaults being 65536 and 65536*1024 respectively).

- When the tornado queue is full an async ErrSlowConsumer error is thrown to the `error_handler` if it is set

- Fixes not throwing away subscriptions on close and auto unsubscribe

- Formatting fixes