### PR TITLE
flush pongs

### DIFF
--- a/nats/io/client.py
+++ b/nats/io/client.py
@@ -734,6 +734,8 @@ class Client(object):
         sending an `-ERR 'Stale Connection'` error.
         """
         yield self.send_command(PONG_PROTO)
+        if self._flush_queue.empty():
+            yield self._flush_pending()
 
     @tornado.gen.coroutine
     def _process_pong(self):


### PR DESCRIPTION
Pongs weren't being explicitly flushed to the server. If the connection was sitting idle (no publishes/subscribes to flush the connection) it was possible for no pongs to be sent as a response, and the server to sever the connection. Explicitly flushing pongs prevents this.