### PR TITLE
Reworking of internals of the client

### DIFF
--- a/nats/__init__.py
+++ b/nats/__init__.py
@@ -12,5 +12,5 @@
 # limitations under the License.
 #
 
-__version__ = b'0.7.2'
+__version__ = b'0.8.0'
 __lang__ = b'python2'

--- a/nats/io/client.py
+++ b/nats/io/client.py
@@ -1288,9 +1288,6 @@ class Client(object):
             except tornado.iostream.StreamClosedError as e:
                 self._pending = pending + self._pending
                 self._pending_size += pending_size
-                # self._err = e
-                # if self._error_cb is not None and not self.is_reconnecting:
-                #     self._error_cb(e)
                 yield self._process_op_err(e)
 
     @tornado.gen.coroutine


### PR DESCRIPTION
Major changes to the client so that its structure, behavior and API are closer to that of the [Asyncio NATS](https://github.com/nats-io/) client works.

Also included:

- Fixed issue of not dropping servers after `max_reconnect_attempts` when authorization failed.

- Adds `'loop'` and `'closed_cb'` parameter so that API is similar as Asyncio NATS

- Close callback was getting called whenever TCP connection was closed due to being used as the `set_close_callback`.  Now it is only called when the NATS client gives up reconnecting as in other clients.

- Tests now used the event callbacks and futures to be more deterministic