### PR TITLE
Simpler connect

### DIFF
--- a/examples/nats-sub/__main__.py
+++ b/examples/nats-sub/__main__.py
@@ -51,13 +51,12 @@ def main():
     opts = {"servers": servers}
     yield nc.connect(**opts)
 
+    @tornado.gen.coroutine
     def handler(msg):
         print("[Received: {0}] {1}".format(msg.subject, msg.data))
 
     print("Subscribed to '{0}'".format(args.subject))
-    future = nc.subscribe(args.subject, args.queue, handler)
-    sid = future.result()
-
+    yield nc.subscribe(args.subject, args.queue, handler)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Implements simpler connect syntax

```python
# Assume 'nats://' scheme
yield nc.connect("demo.nats.io:4222")

# Complete with scheme a la Go client classic usage.
yield nc.connect("nats://demo.nats.io:4222")

# Use default 4222 port.
yield nc.connect("demo.nats.io")

# Explicit cluster list
yield nc.connect(servers="demo.nats.io")

# TLS example
yield nc.connect("tls://demo.nats.io:4443")
```