### PR TITLE
Fix BadYieldError: yielded unknown object None in the _process_msg

### DIFF
--- a/nats/io/client.py
+++ b/nats/io/client.py
@@ -907,7 +907,7 @@ class Client(object):
                     yield self._error_cb(ErrSlowConsumer())
                 raise tornado.gen.Return()
 
-            yield sub.pending_queue.put_nowait(msg)
+            sub.pending_queue.put_nowait(msg)
         except tornado.queues.QueueFull:
             if self._error_cb is not None:
                 yield self._error_cb(ErrSlowConsumer())


### PR DESCRIPTION
Yield on sub.pending_queue.put_nowait(msg) was causing

ERROR:tornado.application:Exception in callback <functools.partial object at 0x7f058b7855d0>
Traceback (most recent call last):
  File "/usr/lib64/python2.7/site-packages/tornado/ioloop.py", line 591, in _run_callback
    ret = callback()
  File "/usr/lib64/python2.7/site-packages/tornado/stack_context.py", line 274, in null_wrapper
    return fn(*args, **kwargs)
  File "/usr/lib64/python2.7/site-packages/tornado/ioloop.py", line 597, in <lambda>
    self.add_future(ret, lambda f: f.result())
  File "/usr/lib64/python2.7/site-packages/tornado/concurrent.py", line 214, in result
    raise_exc_info(self._exc_info)
  File "/usr/lib64/python2.7/site-packages/tornado/gen.py", line 876, in run
    yielded = self.gen.throw(*exc_info)
  File "/usr/lib/python2.7/site-packages/nats/protocol/parser.py", line 151, in parse
    yield self.nc._process_msg(sid, subject, reply, payload)
  File "/usr/lib64/python2.7/site-packages/tornado/gen.py", line 870, in run
    value = future.result()
  File "/usr/lib64/python2.7/site-packages/tornado/concurrent.py", line 214, in result
    raise_exc_info(self._exc_info)
  File "/usr/lib64/python2.7/site-packages/tornado/gen.py", line 876, in run
    yielded = self.gen.throw(*exc_info)
  File "/usr/lib/python2.7/site-packages/nats/io/client.py", line 910, in _process_msg
    yield sub.pending_queue.put_nowait(msg)
  File "/usr/lib64/python2.7/site-packages/tornado/gen.py", line 870, in run
    value = future.result()
  File "/usr/lib64/python2.7/site-packages/tornado/concurrent.py", line 214, in result
    raise_exc_info(self._exc_info)
  File "/usr/lib64/python2.7/site-packages/tornado/gen.py", line 956, in handle_yield
    self.future = convert_yielded(yielded)
  File "/usr/lib/python2.7/site-packages/singledispatch.py", line 210, in wrapper
    return dispatch(args[0].__class__)(*args, **kw)
  File "/usr/lib64/python2.7/site-packages/tornado/gen.py", line 1026, in convert_yielded
    raise BadYieldError("yielded unknown object %r" % (yielded,))
BadYieldError: yielded unknown object None