### PR TITLE
handle all exceptions on reconnect

### DIFF
--- a/nats/io/client.py
+++ b/nats/io/client.py
@@ -323,7 +323,7 @@ class Client(object):
                 self._status = Client.CONNECTING
                 yield self._process_connect_init()
                 break
-            except (socket.error, tornado.iostream.StreamClosedError) as e:
+            except Exception as e:
                 self._status = Client.DISCONNECTED
                 self._err = e
                 if self._error_cb is not None:
@@ -1127,7 +1127,7 @@ class Client(object):
                 self._status = Client.DISCONNECTED
                 yield self.close()
                 break
-            except (socket.error, NatsError, tornado.iostream.StreamClosedError) as e:
+            except Exception as e:
                 self._err = e
                 if self._error_cb is not None:
                     self._error_cb(e)
@@ -1203,7 +1203,7 @@ class Client(object):
                 yield self._server_connect(s)
                 self._current_server = s
                 break
-            except (socket.error, tornado.iostream.StreamClosedError) as e:
+            except Exception as e:
                 s.last_attempt = time.time()
                 s.reconnects += 1
 

--- a/nats/io/client.py
+++ b/nats/io/client.py
@@ -323,6 +323,8 @@ class Client(object):
                 self._status = Client.CONNECTING
                 yield self._process_connect_init()
                 break
+            except ErrNoServers:
+                raise
             except Exception as e:
                 self._status = Client.DISCONNECTED
                 self._err = e

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1082,10 +1082,13 @@ class ClientTest(tornado.testing.AsyncTestCase):
             "read_chunk_size": 10,
             "error_cb": c.error_cb,
             "close_cb": c.close_cb,
-            "disconnected_cb": c.disconnected_cb
+            "disconnected_cb": c.disconnected_cb,
+            "max_reconnect_attempts": 1,
         }
-        with self.assertRaises(tornado.iostream.StreamBufferFullError):
+        with self.assertRaises(ErrNoServers):
             yield c.nc.connect(**options)
+        self.assertEqual(
+            tornado.iostream.StreamBufferFullError, c.nc.last_error().__class__)
         self.assertFalse(c.nc.is_connected)
         self.assertEqual(1024, c.nc._max_read_buffer_size)
         self.assertEqual(50, c.nc._max_write_buffer_size)


### PR DESCRIPTION
We were running into problems on reconnects because exceptions other than the explicitly caught ones (like future timeouts) were being thrown. This caused the reconnect loop to be aborted prematurely and the closed callback was not called either.

I feel like catching all exceptions is the proper thing to do, as I don't think any exceptions should really abort the reconnect loop, as well as future proofing this against other exception types.

@wallyqs @charliestrawn 